### PR TITLE
fix: normalize hyphens in camel_to_snake (closes #3)

### DIFF
--- a/src/blueprint/agent_generator/cli/commands/create.py
+++ b/src/blueprint/agent_generator/cli/commands/create.py
@@ -86,8 +86,6 @@ def create_handler(args: Namespace) -> None:
     # Use naming utilities to normalize the handler name
     class_name, snake_name, file_name = normalize_component_name(args.name, "handler")
 
-    # Ensure filename doesn't contain hyphens (convert to snake_case for imports)
-    file_name = file_name.replace("-", "_")
     module_name = file_name[:-3]  # Remove .py extension
     output_file = output_dir / file_name
 
@@ -180,8 +178,6 @@ def create_service(args: Namespace) -> None:
     # Use naming utilities to normalize the service name
     class_name, snake_name, file_name = normalize_component_name(args.name, "service")
 
-    # Ensure filename doesn't contain hyphens (convert to snake_case for imports)
-    file_name = file_name.replace("-", "_")
     module_name = file_name[:-3]  # Remove .py extension
     output_file = output_dir / file_name
 
@@ -282,8 +278,6 @@ def create_api(args: Namespace) -> None:
     # Use naming utilities to normalize the API name
     class_name, _, file_name = normalize_component_name(args.name, "api")
 
-    # Ensure filename doesn't contain hyphens (convert to snake_case for imports)
-    file_name = file_name.replace("-", "_")
     module_name = file_name[:-3]  # Remove .py extension
     api_output_file = api_output_dir / file_name
 
@@ -534,9 +528,6 @@ def create_agent(args: Namespace) -> None:
     # Use naming utilities to normalize the agent name
     class_name, snake_name, file_name = normalize_component_name(args.name, "agent")
 
-    # Ensure filename doesn't contain hyphens (convert to snake_case for imports)
-    file_name = file_name.replace("-", "_")
-    snake_name = snake_name.replace("-", "_")  # Also fix snake_name
     module_name = file_name[:-3]  # Remove .py extension
 
     # Get project root and directories
@@ -686,8 +677,6 @@ def create_scheduler(args: Namespace) -> None:
     # Use naming utilities to normalize the scheduler name
     class_name, snake_name, file_name = normalize_component_name(args.name, "scheduler")
 
-    # Ensure filename doesn't contain hyphens (convert to snake_case for imports)
-    file_name = file_name.replace("-", "_")
     module_name = file_name[:-3]  # Remove .py extension
     output_file = output_dir / file_name
 

--- a/src/blueprint/agent_generator/cli/utils/naming_utils.py
+++ b/src/blueprint/agent_generator/cli/utils/naming_utils.py
@@ -53,14 +53,15 @@ def to_class_name(name: str) -> str:
 
 def camel_to_snake(name: str) -> str:
     """
-    Convert CamelCase to snake_case.
+    Convert CamelCase or kebab-case to snake_case.
 
     Args:
-        name: CamelCase string
+        name: CamelCase or kebab-case string
 
     Returns:
         snake_case string
     """
+    name = name.replace("-", "_")
     # Insert underscore before capital letters (except first)
     s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     # Insert underscore before capital letters preceded by lowercase

--- a/tests/unit/agent_generator/cli/utils/test_naming_utils.py
+++ b/tests/unit/agent_generator/cli/utils/test_naming_utils.py
@@ -90,6 +90,11 @@ class TestCamelToSnake:
         """Should handle single word lowercase."""
         assert camel_to_snake("agent") == "agent"
 
+    def test_camel_to_snake_kebab_case(self) -> None:
+        """Should convert kebab-case to snake_case."""
+        assert camel_to_snake("my-agent") == "my_agent"
+        assert camel_to_snake("cleanup-job") == "cleanup_job"
+
 
 class TestToSnakeCase:
     """Test suite for to_snake_case function."""
@@ -139,10 +144,16 @@ class TestNormalizeComponentName:
     def test_normalize_scheduler_kebab_case(self) -> None:
         """Should normalize scheduler name from kebab-case."""
         class_name, snake_name, filename = normalize_component_name("cleanup-job", "scheduler")
-        # camel_to_snake treats kebab-case differently, preserving the dash
         assert class_name == "CleanupJobScheduler"
-        assert snake_name == "cleanup-job_scheduler"
-        assert filename == "cleanup-job_scheduler.py"
+        assert snake_name == "cleanup_job_scheduler"
+        assert filename == "cleanup_job_scheduler.py"
+
+    def test_normalize_handler_kebab_case(self) -> None:
+        """Should normalize handler name from kebab-case."""
+        class_name, snake_name, filename = normalize_component_name("my-agent", "handler")
+        assert class_name == "MyAgentHandler"
+        assert snake_name == "my_agent_handler"
+        assert filename == "my_agent_handler.py"
 
 
 class TestAddImportToMain:


### PR DESCRIPTION
## Summary

- Fix `camel_to_snake` in `naming_utils.py`: prepend `name.replace("-", "_")` so kebab-case input (e.g. `my-agent`) produces valid snake_case identifiers instead of names with literal hyphens
- Remove five ad-hoc `.replace("-", "_")` workarounds in `create.py` that were patching filenames but leaving `snake_name` broken
- Add two new tests (`test_camel_to_snake_kebab_case`, `test_normalize_handler_kebab_case`); update `test_normalize_scheduler_kebab_case` from broken-behavior assertions to correct expected values

## Test Plan

- [ ] `uv run pytest tests/unit/agent_generator/` — 53 passed (was 51 before new tests)
- [ ] `normalize_component_name("my-agent", "handler")` → `("MyAgentHandler", "my_agent_handler", "my_agent_handler.py")`
- [ ] `camel_to_snake("my-agent")` → `"my_agent"`
- [ ] CamelCase regression: `camel_to_snake("TestAgent")` still → `"test_agent"`

Closes #3

Related: [spec](../blob/develop/docs/specs/2026-05-18-fix-kebab-case-naming.md) · [plan](../blob/develop/docs/plans/2026-05-18-fix-kebab-case-naming.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)