### PR TITLE
feat(handler): SessionsJobHandler job-lifecycle base (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@
 - **`SessionsJobHandler`** (`blueprint.agents.handler`) — shared job-lifecycle base for
   sessions-service SSE handlers (#19). Subclasses set `JOB_TYPE`, `PAYLOAD_MODEL`,
   `RESULT_MODEL` and implement `process()`; the base wraps fetch → validate → start →
-  process → complete with two-stage idempotency (in-flight guard + post-start seen-set)
-  and a centralised error→status mapping (cancel / complete-with-error / retry-pending).
+  process → complete with two-stage idempotency (an in-flight guard for concurrent
+  duplicates plus a **terminal-only** seen-set populated only on complete/cancel) and a
+  centralised error→status mapping (cancel / complete-with-error / left-eligible-for-
+  redelivery). Post-start retryable/critical failures are not silently dropped, but are
+  not yet fully resumable — svc-sessions rejects `RUNNING→RUNNING` (409), so true resume
+  awaits a re-pend/lease capability there (avs.ai.idac.service-sessions#59).
   Additive and backwards compatible — `EventHandlerBase` is unchanged.
 
 ## [0.5.0] - 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## [0.6.0] - Planned
 
+### Added
+- **`SessionsJobHandler`** (`blueprint.agents.handler`) — shared job-lifecycle base for
+  sessions-service SSE handlers (#19). Subclasses set `JOB_TYPE`, `PAYLOAD_MODEL`,
+  `RESULT_MODEL` and implement `process()`; the base wraps fetch → validate → start →
+  process → complete with two-stage idempotency (in-flight guard + post-start seen-set)
+  and a centralised error→status mapping (cancel / complete-with-error / retry-pending).
+  Additive and backwards compatible — `EventHandlerBase` is unchanged.
+
 ## [0.5.0] - 2026-03-05
 
 ### Architecture Refactoring - Component System Streamlining

--- a/docs/plans/2026-06-10-sessions-job-handler.md
+++ b/docs/plans/2026-06-10-sessions-job-handler.md
@@ -4,6 +4,25 @@
 **Spec source:** issue #19 body (acceptance criteria) + analyser#13 (lifecycle parity reference)
 **Repo:** `blueprint.agent-service` (code-follows rule — the framework change lives here)
 
+## Amendment (supersedes the "after `start_job`" idempotency wording below)
+
+PR #21 review found that populating `_seen` immediately after `start_job` (as the
+"Lifecycle order" / step 5 below describe) silently drops the redelivery of any job that
+*started* but then re-raised a non-terminal error (`RetryableHandlerError` / `OSError` /
+`TimeoutError` / `CriticalHandlerError`, or complete-exhaustion) — violating the
+"left pending = retryable" contract. **Final implementation:** `_seen` is **terminal-only**
+— populated only on a terminal outcome (successful complete, cancel, error-result complete).
+`_in_flight` still guards concurrent duplicates. Post-start non-terminal failures stay in
+*neither* set, so they remain eligible for redelivery.
+
+Known bound: once `start_job` moved a job `PENDING→RUNNING`, a redelivery re-calls
+`start_job` and svc-sessions rejects `RUNNING→RUNNING` with 409 — eligible-for-redelivery is
+not yet fully *resumable*. Tracked in avs.ai.idac.service-sessions#59. An idempotent
+"swallow 409-already-running" start was rejected: under multi-replica SSE it would turn a
+benign duplicate-stop into double-`process()`.
+
+Read the sections below with this amendment in force.
+
 ## Goal
 
 Add `blueprint.agents.handler.SessionsJobHandler` — a shared base that wraps the

--- a/docs/plans/2026-06-10-sessions-job-handler.md
+++ b/docs/plans/2026-06-10-sessions-job-handler.md
@@ -1,0 +1,148 @@
+# Plan — Promote `SessionsJobHandler` to framework
+
+**Issue:** bechtleav360/...blueprint#19
+**Spec source:** issue #19 body (acceptance criteria) + analyser#13 (lifecycle parity reference)
+**Repo:** `blueprint.agent-service` (code-follows rule — the framework change lives here)
+
+## Goal
+
+Add `blueprint.agents.handler.SessionsJobHandler` — a shared base that wraps the
+sessions job lifecycle (fetch → validate → start → process → complete) so the four
+SSE-consuming agents stop duplicating ~100 LOC each.
+
+## Resolved design decisions
+
+1. **`process()` signature — raw dict context.**
+   `async def process(self, payload: PAYLOAD_MODEL, context: dict[str, Any]) -> RESULT_MODEL`.
+   No new `HandlerContext` type. Matches the existing `EventHandlerBase` convention; the
+   base unpacks `session_id`/`job_id`/`session_key`/`sessions_api_client` from the dict for
+   its own lifecycle calls, then passes the same dict through to `process()`.
+
+2. **Error → terminal-state mapping — verified against svc-sessions.**
+   svc-sessions `JobStatus` enum defines `FAILED`, but there is **no transition into it**
+   (`RUNNING→COMPLETED`, `RUNNING→CANCELLED` only) and **no API to set it**. Only COMPLETED
+   and CANCELLED are reachable. Mapping:
+
+   | `process()` raises | Base action | Terminal state |
+   |---|---|---|
+   | (validation fails, before `process`) `InvalidEventError` | `cancel_job(reason=...)` | CANCELLED |
+   | `InvalidEventError` | `cancel_job(reason=...)` | CANCELLED |
+   | `RetryableHandlerError` | re-raise | PENDING (SessionsBus leaves it) |
+   | `OSError`, `TimeoutError` | wrap → re-raise `RetryableHandlerError` | PENDING |
+   | `ValueError`, any other `Exception` | `complete_job(result={"status":"failed","error":...})` | COMPLETED (result signals failure) |
+
+   The base **owns** the mapping (calls `cancel_job`/`complete_job` itself); it only re-raises
+   for the retryable bucket so SessionsBus's existing handler leaves the job pending.
+   `InvalidEventError` is NOT re-raised after the base cancels (avoids double-cancel +
+   illegal `CANCELLED→CANCELLED` transition).
+
+3. **`agent_id`** read from `self.config["sessions_service"]["agent_id"]` on `on_startup`;
+   required (raise `ValueError` if missing — no hardcoded default).
+
+## Lifecycle order (`handle_event`)
+
+1. Unpack `session_id`, `job_id`, `session_key`, `api_client` from `context`.
+2. **Idempotency — two-stage (revised per review).** A single permanent seen-set added
+   *before* a durable lifecycle point would strand jobs: a transient `get_job_detail`/
+   `start_job` failure raises `RetryableHandlerError`, SessionsBus leaves the job PENDING,
+   and a later replayed `job_created` would be dropped because the id is already "seen".
+   Use the analyser#13 model:
+   - **In-flight guard** — synchronous check-and-add on `_in_flight: set[UUID]` at entry
+     (no `await` between test and `add`). Handles *concurrent* duplicate notifications.
+     Removed in a `finally` so a failed pre-start attempt is retryable.
+   - **Terminal seen-set** — `_seen: set[UUID]`, id added **only after `start_job` succeeds**.
+     Handles *replayed* notifications for an already-started/completed job.
+   - Duplicate hitting either guard → log + return `None` (no-op). Transient pre-start
+     failure leaves the id in *neither* set → a later duplicate proceeds normally.
+3. `get_job_detail` → raw payload dict.
+4. Validate payload → `PAYLOAD_MODEL` (`InvalidEventError` on failure → cancel; do this
+   **before** `start_job` so we never start a job we immediately fail).
+5. `start_job(session_id, job_id, agent_id, session_key)` → on success add `job_id` to `_seen`.
+6. `result = await self.process(payload, context)` → `RESULT_MODEL`.
+7. `complete_job` with retry (3 attempts, 2s backoff) on transient `httpx` errors.
+8. Error mapping per table above.
+9. Structured log line per stage: `session_id`, `job_id`, `job_type`, `status`, `duration_ms`.
+
+`get_job_detail`/`start_job` raising transient `httpx` errors → wrap → `RetryableHandlerError`
+(consistent with the `OSError`/`TimeoutError` bucket), so SessionsBus retry semantics are preserved.
+
+## Surface
+
+```python
+class SessionsJobHandler(EventHandlerBase, ABC):
+    JOB_TYPE: ClassVar[str]
+    PAYLOAD_MODEL: ClassVar[type[BaseModel]]
+    RESULT_MODEL: ClassVar[type[BaseModel]]
+
+    async def can_handle_event(self, event, context) -> bool:
+        return event.type == f"sessions.job.created.{self.JOB_TYPE}"
+
+    async def handle_event(self, event, context) -> HandlerResult | None: ...  # lifecycle, final
+
+    @abstractmethod
+    async def process(self, payload: BaseModel, context: dict[str, Any]) -> BaseModel: ...
+```
+
+- Export `SessionsJobHandler` from `blueprint/agents/handler/__init__.py`.
+- `can_handle_event` returning `False` for unknown `job_type` satisfies AC-7 (unknown type
+  ignored, not raised) — no extra code.
+
+## Steps
+
+1. **TDD first** — write `tests/.../test_sessions_job_handler.py` covering: happy path,
+   concurrent duplicate `job_id` no-op, replayed duplicate after `start_job` no-op,
+   **transient `get_job_detail` failure then later duplicate proceeds** (not stranded),
+   **transient `start_job` failure then later duplicate proceeds**, payload validation
+   failure → cancel, `process` raising `ValueError`/generic `Exception` → complete-with-
+   error-result, `process` raising `OSError`/`TimeoutError` → `RetryableHandlerError`
+   (pending), `complete_job` retry then exhaustion, unknown `job_type` no-op. Mock
+   `SessionsApiClient`.
+2. Implement `src/blueprint/agents/handler/sessions_job_handler.py`.
+3. Wire export in `handler/__init__.py` (`__all__`).
+4. **CHANGELOG entry under the existing `[0.6.0]` section only. Do NOT touch
+   `pyproject.toml` version** — `AGENTS.md` states versioning is handled by CI publishing;
+   manual bumps are forbidden. (Supersedes the issue's "SemVer minor bump" in AC-4: the
+   minor bump is the publish pipeline's job, the changelog entry is ours.)
+5. `ruff check` + `black` + `mypy` + `pytest`.
+
+## Test scenarios → acceptance criteria
+
+| Scenario | AC |
+|---|---|
+| `test_happy_path_runs_full_lifecycle` | AC-1, AC-2 |
+| `test_concurrent_duplicate_job_id_is_noop` (in-flight guard) | AC-3 (analyser#13 AC-5) |
+| `test_replayed_duplicate_after_start_is_noop` (terminal seen-set) | AC-3 |
+| `test_transient_get_job_detail_failure_then_duplicate_proceeds` | AC-3 (anti-stranding) |
+| `test_transient_start_job_failure_then_duplicate_proceeds` | AC-3 (anti-stranding) |
+| `test_invalid_payload_cancels_job` | AC-3 |
+| `test_value_error_completes_with_failed_result` | AC-3 |
+| `test_oserror_raises_retryable_leaves_pending` | AC-3 |
+| `test_generic_exception_completes_with_failed_result` | AC-3 |
+| `test_complete_job_retry_then_success` / `test_retry_exhaustion` | AC-3 |
+| `test_unknown_job_type_not_handled` | AC-5 |
+| export importable; `EventHandlerBase` untouched | AC-1, AC-5 |
+
+## Scope findings (surfaced, not fixed here)
+
+- **`SessionsApiClient.cancel_job` posts to `/sessions/{sid}/jobs/{jid}/cancel`, but svc-sessions
+  (`api/jobs.py`) exposes no such route.** Pre-existing client/server mismatch — the cancel
+  path may 404 at runtime. Out of scope for #19; will file a svc-sessions follow-up issue and
+  link it. Unit tests assert the base *calls* `cancel_job` (mocked); they do **not** claim the
+  invalid-payload cancel path is proven end-to-end against a live svc-sessions.
+- **`JobStatus.FAILED` is dead** (unreachable). analyser#13 AC-4 "marks job failed" is
+  aspirational; real mechanism is cancel-with-reason or complete-with-error-result.
+
+## Out of scope (per issue)
+
+Cross-restart idempotency, progress/partial-result publishing, IMAP sources, the per-agent
+migration PRs (post-release).
+
+## Risk
+
+Base change ripples to all consumers → keep base small + abstract, SemVer minor, land before
+second consumer migrates. Unbounded idempotency `set` — acceptable for current load (noted).
+
+## Rollback
+
+Pure addition (new file + one export line + CHANGELOG). Revert the commit; no consumer
+depends on it until migration PRs land.

--- a/src/blueprint/agents/handler/__init__.py
+++ b/src/blueprint/agents/handler/__init__.py
@@ -1,4 +1,5 @@
 from .handler_chain import HandlerChain
 from .event_handler_base import EventHandlerBase
+from .sessions_job_handler import SessionsJobHandler
 
-__all__ = ["HandlerChain", "EventHandlerBase"]
+__all__ = ["HandlerChain", "EventHandlerBase", "SessionsJobHandler"]

--- a/src/blueprint/agents/handler/sessions_job_handler.py
+++ b/src/blueprint/agents/handler/sessions_job_handler.py
@@ -17,10 +17,20 @@ Concrete handlers set three class vars (``JOB_TYPE``, ``PAYLOAD_MODEL``,
             ...
 
 Idempotency is two-stage (see :meth:`handle_event`): an in-flight guard for
-concurrent duplicate notifications, plus a seen-set populated only after
-``start_job`` succeeds for replays of already-started jobs. A job that fails
-*before* ``start_job`` (transient fetch/start error) is left in neither set so a
-later redelivery is not stranded.
+concurrent duplicate notifications, plus a seen-set populated only on a
+*terminal* outcome (complete / cancel / error-result-complete) to drop replays
+of finished jobs. A job that fails before reaching a terminal state — transient
+fetch/start error, or a post-start retryable/critical failure — is left in
+neither set, so it stays eligible for redelivery rather than being silently
+ignored.
+
+Caveat: once ``start_job`` has moved a job PENDING->RUNNING, a redelivery that
+re-enters this handler will call ``start_job`` again and svc-sessions rejects it
+(RUNNING->RUNNING is not a valid transition -> 409). So post-start retryable
+failures are *eligible* for redelivery but not yet cleanly *resumable* — true
+post-start resume needs a svc-sessions re-pend/resume capability (tracked
+separately). The ``_seen`` fix here removes the silent-ignore; it does not add a
+resume path.
 
 Error -> terminal-state mapping (svc-sessions can only reach COMPLETED/CANCELLED;
 there is no reachable ``failed`` state):
@@ -77,7 +87,7 @@ class SessionsJobHandler(EventHandlerBase, ABC):
         self._agent_id: str | None = None
         # Concurrent duplicate guard; populated at entry, cleared in `finally`.
         self._in_flight: set[UUID] = set()
-        # Replay guard; populated only after `start_job` succeeds.
+        # Replay guard; populated only on a terminal outcome (complete/cancel).
         self._seen: set[UUID] = set()
 
     async def on_startup(self) -> None:
@@ -143,12 +153,8 @@ class SessionsJobHandler(EventHandlerBase, ABC):
             try:
                 payload = self.PAYLOAD_MODEL.model_validate(raw_payload)
             except PydanticValidationError as exc:
-                self._log(session_id, job_id, "cancelled", started)
-                await api_client.cancel_job(
-                    session_id=session_id,
-                    job_id=job_id,
-                    session_key=session_key,
-                    reason=f"invalid payload for {self.PAYLOAD_MODEL.__name__}: {exc}",
+                await self._cancel(
+                    api_client, session_id, job_id, session_key, started, reason=f"invalid payload for {self.PAYLOAD_MODEL.__name__}: {exc}"
                 )
                 return None
 
@@ -157,9 +163,12 @@ class SessionsJobHandler(EventHandlerBase, ABC):
                 await api_client.start_job(session_id, job_id, self._agent_id, session_key)
             except httpx.RequestError as exc:
                 raise RetryableHandlerError(status="start_failed", reason=f"start_job failed: {exc}") from exc
-            self._seen.add(job_id)
 
             # --- Process + map errors to terminal states. ---
+            # NOTE: `_seen` (the redelivery guard) is populated ONLY on a terminal
+            # outcome below — never merely because `start_job` succeeded. A job that
+            # started but then re-raises (retryable / critical) must stay out of
+            # `_seen` so a redelivery is not silently ignored.
             try:
                 result = await self.process(payload, context)
             except (RetryableHandlerError, CriticalHandlerError):
@@ -167,27 +176,58 @@ class SessionsJobHandler(EventHandlerBase, ABC):
                 # Both keep their framework semantics; never neutralise into a result.
                 raise
             except InvalidEventError as exc:
-                self._log(session_id, job_id, "cancelled", started)
-                await api_client.cancel_job(session_id=session_id, job_id=job_id, session_key=session_key, reason=str(exc))
+                await self._cancel(api_client, session_id, job_id, session_key, started, reason=str(exc))
                 return None
             except (OSError, TimeoutError) as exc:
                 raise RetryableHandlerError(status="process_transient", reason=f"process transient error: {exc}") from exc
             except Exception as exc:  # ValueError + any other -> complete with error result.
-                self._log(session_id, job_id, "completed_failed", started)
-                await api_client.complete_job(
-                    session_id=session_id,
-                    job_id=job_id,
-                    session_key=session_key,
-                    result={"status": "failed", "error": str(exc)},
+                await self._complete(
+                    api_client,
+                    session_id,
+                    job_id,
+                    session_key,
+                    started,
+                    {"status": "failed", "error": str(exc)},
+                    status_log="completed_failed",
                 )
                 return None
 
-            # --- Complete (with retry on transient HTTP errors). ---
-            await self._complete_with_retry(api_client, session_id, job_id, session_key, result.model_dump())
-            self._log(session_id, job_id, "completed", started)
+            # --- Complete (success). ---
+            await self._complete(api_client, session_id, job_id, session_key, started, result.model_dump(), status_log="completed")
             return None
         finally:
             self._in_flight.discard(job_id)
+
+    async def _complete(
+        self,
+        api_client: Any,
+        session_id: UUID,
+        job_id: UUID,
+        session_key: str,
+        started: float,
+        result: dict[str, Any],
+        *,
+        status_log: str,
+    ) -> None:
+        """Terminal completion (success or error-result) with shared retry, then mark seen."""
+        await self._complete_with_retry(api_client, session_id, job_id, session_key, result)
+        self._seen.add(job_id)
+        self._log(session_id, job_id, status_log, started)
+
+    async def _cancel(
+        self,
+        api_client: Any,
+        session_id: UUID,
+        job_id: UUID,
+        session_key: str,
+        started: float,
+        *,
+        reason: str,
+    ) -> None:
+        """Terminal cancellation, then mark seen so a redelivery does not re-cancel."""
+        await api_client.cancel_job(session_id=session_id, job_id=job_id, session_key=session_key, reason=reason)
+        self._seen.add(job_id)
+        self._log(session_id, job_id, "cancelled", started)
 
     async def _complete_with_retry(
         self,

--- a/src/blueprint/agents/handler/sessions_job_handler.py
+++ b/src/blueprint/agents/handler/sessions_job_handler.py
@@ -1,0 +1,232 @@
+"""Shared job-lifecycle base for sessions-service SSE handlers (issue #19).
+
+`SessionsJobHandler` wraps the repetitive job lifecycle that every SSE-consuming
+agent otherwise duplicates: fetch job detail, validate the payload, mark the job
+running, run the agent-specific work, and report the result back — with a single
+centralised error->status mapping and per-process idempotency.
+
+Concrete handlers set three class vars (``JOB_TYPE``, ``PAYLOAD_MODEL``,
+``RESULT_MODEL``) and implement the single abstract :meth:`process` method::
+
+    class MyHandler(SessionsJobHandler):
+        JOB_TYPE = "analyse.batch"
+        PAYLOAD_MODEL = BatchPayload
+        RESULT_MODEL = BatchResult
+
+        async def process(self, payload: BatchPayload, context: dict) -> BatchResult:
+            ...
+
+Idempotency is two-stage (see :meth:`handle_event`): an in-flight guard for
+concurrent duplicate notifications, plus a seen-set populated only after
+``start_job`` succeeds for replays of already-started jobs. A job that fails
+*before* ``start_job`` (transient fetch/start error) is left in neither set so a
+later redelivery is not stranded.
+
+Error -> terminal-state mapping (svc-sessions can only reach COMPLETED/CANCELLED;
+there is no reachable ``failed`` state):
+
+================================  =====================================
+``process`` raises                Outcome
+================================  =====================================
+``InvalidEventError``             cancel_job (CANCELLED)
+``RetryableHandlerError``         re-raised -> SessionsBus leaves PENDING
+``OSError`` / ``TimeoutError``    wrapped -> RetryableHandlerError -> PENDING
+``ValueError`` / other            complete_job with error-shaped result
+================================  =====================================
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+from uuid import UUID
+
+import httpx
+
+from pydantic import BaseModel, ValidationError as PydanticValidationError
+
+from ..models import HandlerResult
+from ..models.errors import CriticalHandlerError, InvalidEventError, RetryableHandlerError
+from ..models.events import GenericCloudEvent
+from .event_handler_base import EventHandlerBase
+
+logger = logging.getLogger(__name__)
+
+
+class SessionsJobHandler(EventHandlerBase, ABC):
+    """Abstract base wrapping the sessions-service job lifecycle.
+
+    Subclasses MUST set :attr:`JOB_TYPE`, :attr:`PAYLOAD_MODEL`,
+    :attr:`RESULT_MODEL` and implement :meth:`process`.
+    """
+
+    JOB_TYPE: ClassVar[str]
+    PAYLOAD_MODEL: ClassVar[type[BaseModel]]
+    RESULT_MODEL: ClassVar[type[BaseModel]]
+
+    #: Attempts for the terminal ``complete_job`` call on transient HTTP errors.
+    COMPLETE_MAX_ATTEMPTS: ClassVar[int] = 3
+    #: Backoff between ``complete_job`` attempts, in seconds.
+    COMPLETE_RETRY_BACKOFF_SECONDS: ClassVar[float] = 2.0
+
+    def __init__(self, priority: int = 100) -> None:
+        super().__init__(priority=priority)
+        self._agent_id: str | None = None
+        # Concurrent duplicate guard; populated at entry, cleared in `finally`.
+        self._in_flight: set[UUID] = set()
+        # Replay guard; populated only after `start_job` succeeds.
+        self._seen: set[UUID] = set()
+
+    async def on_startup(self) -> None:
+        """Resolve the agent id from ``sessions_service`` config (required)."""
+        sessions_config = self.config.get("sessions_service") or {}
+        self._agent_id = sessions_config.get("agent_id")
+        if not self._agent_id:
+            raise ValueError("sessions_service.agent_id is required")
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def can_handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> bool:
+        """Handle only this subclass's job type; unknown types are ignored."""
+        return event.type == f"sessions.job.created.{self.JOB_TYPE}"
+
+    @abstractmethod
+    async def process(self, payload: BaseModel, context: dict[str, Any]) -> BaseModel:
+        """Run the agent-specific work for one validated job.
+
+        Args:
+            payload: The validated :attr:`PAYLOAD_MODEL` instance.
+            context: The processing context dict (``session_id``, ``job_id``,
+                ``session_key``, ``sessions_api_client``, ...).
+
+        Returns:
+            A :attr:`RESULT_MODEL` instance whose ``model_dump()`` is submitted
+            via ``complete_job``.
+
+        Raising:
+            * ``InvalidEventError`` -> the job is cancelled.
+            * ``RetryableHandlerError`` / ``OSError`` / ``TimeoutError`` -> the job
+              is left pending for redelivery.
+            * any other exception -> the job is completed with an error result.
+        """
+
+    async def handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> HandlerResult | None:
+        session_id = UUID(context["session_id"])
+        job_id = UUID(context["job_id"])
+        session_key: str = context["session_key"]
+        api_client = context["sessions_api_client"]
+
+        # --- Idempotency: synchronous check-and-add, no await in between. ---
+        if job_id in self._in_flight or job_id in self._seen:
+            logger.info(
+                "Duplicate job notification ignored",
+                extra={"session_id": str(session_id), "job_id": str(job_id), "job_type": self.JOB_TYPE, "status": "duplicate"},
+            )
+            return None
+        self._in_flight.add(job_id)
+
+        started = time.monotonic()
+        try:
+            # --- Fetch + validate (before start_job: never start a doomed job). ---
+            try:
+                job_detail = await api_client.get_job_detail(session_id, job_id, session_key)
+            except httpx.RequestError as exc:
+                # Transport-level only. HTTPStatusError (e.g. 403) propagates raw so
+                # SessionsBus can run its session-key-refresh-and-retry recovery.
+                raise RetryableHandlerError(status="fetch_failed", reason=f"get_job_detail failed: {exc}") from exc
+
+            raw_payload = job_detail.get("payload", {}) if isinstance(job_detail, dict) else {}
+            try:
+                payload = self.PAYLOAD_MODEL.model_validate(raw_payload)
+            except PydanticValidationError as exc:
+                self._log(session_id, job_id, "cancelled", started)
+                await api_client.cancel_job(
+                    session_id=session_id,
+                    job_id=job_id,
+                    session_key=session_key,
+                    reason=f"invalid payload for {self.PAYLOAD_MODEL.__name__}: {exc}",
+                )
+                return None
+
+            # --- Start. ---
+            try:
+                await api_client.start_job(session_id, job_id, self._agent_id, session_key)
+            except httpx.RequestError as exc:
+                raise RetryableHandlerError(status="start_failed", reason=f"start_job failed: {exc}") from exc
+            self._seen.add(job_id)
+
+            # --- Process + map errors to terminal states. ---
+            try:
+                result = await self.process(payload, context)
+            except (RetryableHandlerError, CriticalHandlerError):
+                # Retryable -> SessionsBus leaves pending; Critical -> forces restart.
+                # Both keep their framework semantics; never neutralise into a result.
+                raise
+            except InvalidEventError as exc:
+                self._log(session_id, job_id, "cancelled", started)
+                await api_client.cancel_job(session_id=session_id, job_id=job_id, session_key=session_key, reason=str(exc))
+                return None
+            except (OSError, TimeoutError) as exc:
+                raise RetryableHandlerError(status="process_transient", reason=f"process transient error: {exc}") from exc
+            except Exception as exc:  # ValueError + any other -> complete with error result.
+                self._log(session_id, job_id, "completed_failed", started)
+                await api_client.complete_job(
+                    session_id=session_id,
+                    job_id=job_id,
+                    session_key=session_key,
+                    result={"status": "failed", "error": str(exc)},
+                )
+                return None
+
+            # --- Complete (with retry on transient HTTP errors). ---
+            await self._complete_with_retry(api_client, session_id, job_id, session_key, result.model_dump())
+            self._log(session_id, job_id, "completed", started)
+            return None
+        finally:
+            self._in_flight.discard(job_id)
+
+    async def _complete_with_retry(
+        self,
+        api_client: Any,
+        session_id: UUID,
+        job_id: UUID,
+        session_key: str,
+        result: dict[str, Any],
+    ) -> None:
+        last_exc: httpx.RequestError | None = None
+        for attempt in range(1, self.COMPLETE_MAX_ATTEMPTS + 1):
+            try:
+                await api_client.complete_job(session_id=session_id, job_id=job_id, session_key=session_key, result=result)
+                return
+            except httpx.RequestError as exc:  # transport-level only; status errors propagate raw
+                last_exc = exc
+                logger.warning(
+                    "complete_job attempt %d/%d failed: %s",
+                    attempt,
+                    self.COMPLETE_MAX_ATTEMPTS,
+                    exc,
+                    extra={"session_id": str(session_id), "job_id": str(job_id), "job_type": self.JOB_TYPE, "status": "complete_retry"},
+                )
+                if attempt < self.COMPLETE_MAX_ATTEMPTS and self.COMPLETE_RETRY_BACKOFF_SECONDS > 0:
+                    await asyncio.sleep(self.COMPLETE_RETRY_BACKOFF_SECONDS)
+        raise RetryableHandlerError(
+            status="complete_failed",
+            reason=f"complete_job exhausted {self.COMPLETE_MAX_ATTEMPTS} attempts: {last_exc}",
+        )
+
+    def _log(self, session_id: UUID, job_id: UUID, status: str, started: float) -> None:
+        logger.info(
+            "sessions job %s",
+            status,
+            extra={
+                "session_id": str(session_id),
+                "job_id": str(job_id),
+                "job_type": self.JOB_TYPE,
+                "status": status,
+                "duration_ms": round((time.monotonic() - started) * 1000, 1),
+            },
+        )

--- a/tests/unit/agents/handler/test_sessions_job_handler.py
+++ b/tests/unit/agents/handler/test_sessions_job_handler.py
@@ -1,0 +1,515 @@
+"""Unit tests for SessionsJobHandler (issue #19).
+
+Covers the shared job-lifecycle base: happy path, two-stage idempotency
+(in-flight guard + post-start seen-set), anti-stranding on transient pre-start
+failures, payload validation -> cancel, the process() error->status mapping,
+complete_job retry/exhaustion, and unknown-job_type no-op.
+
+All svc-sessions calls are mocked; these tests do NOT prove the live cancel path
+(svc-sessions exposes no /cancel route — tracked as a separate follow-up).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from pydantic import BaseModel
+
+from blueprint.agents.models.errors import CriticalHandlerError, InvalidEventError, RetryableHandlerError
+from blueprint.agents.models.events import GenericCloudEvent
+
+# Module under test (does not exist yet — RED).
+from blueprint.agents.handler.sessions_job_handler import SessionsJobHandler
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an HTTPStatusError like httpx.Response.raise_for_status() would."""
+    request = httpx.Request("GET", "http://sessions/jobs")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f"{status_code}", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# Test models + concrete handler
+# ---------------------------------------------------------------------------
+
+
+class _Payload(BaseModel):
+    name: str
+
+
+class _Result(BaseModel):
+    ok: bool
+
+
+class _Handler(SessionsJobHandler):
+    """Concrete handler whose process() behaviour is injectable per test."""
+
+    JOB_TYPE = "demo"
+    PAYLOAD_MODEL = _Payload
+    RESULT_MODEL = _Result
+
+    # Zero backoff so retry tests don't sleep.
+    COMPLETE_RETRY_BACKOFF_SECONDS = 0.0
+
+    def __init__(self, *, process_impl: Any = None) -> None:
+        super().__init__()
+        self._process_impl = process_impl
+        self.process_calls = 0
+
+    async def process(self, payload: _Payload, context: dict[str, Any]) -> _Result:
+        self.process_calls += 1
+        if self._process_impl is not None:
+            return await self._process_impl(payload, context)
+        return _Result(ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture
+def job_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture
+def api_client() -> MagicMock:
+    client = MagicMock()
+    client.get_job_detail = AsyncMock(return_value={"payload": {"name": "alice"}})
+    client.start_job = AsyncMock(return_value={})
+    client.complete_job = AsyncMock(return_value={})
+    client.cancel_job = AsyncMock(return_value={})
+    return client
+
+
+@pytest.fixture
+def context(session_id: UUID, job_id: UUID, api_client: MagicMock) -> dict[str, Any]:
+    return {
+        "session_id": str(session_id),
+        "job_id": str(job_id),
+        "session_key": "sk-test",
+        "sessions_api_client": api_client,
+    }
+
+
+@pytest.fixture
+def event() -> GenericCloudEvent:
+    return GenericCloudEvent(id="evt-1", type="sessions.job.created.demo", source="/sessions-service")
+
+
+def _started(mock_config: MagicMock) -> _Handler:
+    """Build a handler with agent_id configured and on_startup applied."""
+    mock_config.get.return_value = {"agent_id": "test-agent"}
+    return _Handler()
+
+
+# ---------------------------------------------------------------------------
+# can_handle_event — job_type routing (AC-5: unknown type ignored)
+# ---------------------------------------------------------------------------
+
+
+class TestCanHandleEvent:
+    async def test_matches_own_job_type(self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent) -> None:
+        handler = _started(mock_config)
+        assert await handler.can_handle_event(event, {}) is True
+
+    async def test_ignores_unknown_job_type(self, mock_config: MagicMock, mock_registry: MagicMock) -> None:
+        handler = _started(mock_config)
+        other = GenericCloudEvent(id="e", type="sessions.job.created.other", source="/s")
+        assert await handler.can_handle_event(other, {}) is False
+
+
+# ---------------------------------------------------------------------------
+# on_startup — agent_id resolution
+# ---------------------------------------------------------------------------
+
+
+class TestStartup:
+    async def test_reads_agent_id_from_config(self, mock_config: MagicMock, mock_registry: MagicMock) -> None:
+        handler = _started(mock_config)
+        await handler.on_startup()
+        assert handler._agent_id == "test-agent"
+
+    async def test_missing_agent_id_raises(self, mock_config: MagicMock, mock_registry: MagicMock) -> None:
+        mock_config.get.return_value = {}
+        handler = _Handler()
+        with pytest.raises(ValueError, match="agent_id"):
+            await handler.on_startup()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — full lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    async def test_runs_full_lifecycle(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        session_id: UUID,
+        job_id: UUID,
+    ) -> None:
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        result = await handler.handle_event(event, context)
+
+        assert result is None
+        api_client.get_job_detail.assert_awaited_once_with(session_id, job_id, "sk-test")
+        api_client.start_job.assert_awaited_once_with(session_id, job_id, "test-agent", "sk-test")
+        assert handler.process_calls == 1
+        api_client.complete_job.assert_awaited_once()
+        # result payload is the dumped RESULT_MODEL
+        _, kwargs = api_client.complete_job.call_args
+        assert kwargs["result"] == {"ok": True}
+        api_client.cancel_job.assert_not_awaited()
+        assert job_id in handler._seen
+        assert job_id not in handler._in_flight
+
+    async def test_get_job_detail_runs_before_start_job(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        calls: list[str] = []
+        api_client.get_job_detail = AsyncMock(side_effect=lambda *a, **k: calls.append("get") or {"payload": {"name": "x"}})
+        api_client.start_job = AsyncMock(side_effect=lambda *a, **k: calls.append("start") or {})
+        handler = _started(mock_config)
+        await handler.on_startup()
+        await handler.handle_event(event, context)
+        assert calls == ["get", "start"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — two-stage (AC-3 / analyser#13 AC-5)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    async def test_replayed_duplicate_after_start_is_noop(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        await handler.handle_event(event, context)
+        # Second delivery of the same job_id is a no-op.
+        await handler.handle_event(event, context)
+
+        assert handler.process_calls == 1
+        api_client.start_job.assert_awaited_once()
+        api_client.complete_job.assert_awaited_once()
+
+    async def test_concurrent_duplicate_is_noop(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        # Simulate a duplicate arriving while the first is mid-flight: pre-seed the
+        # in-flight guard, then a fresh delivery for the same id must no-op.
+        handler._in_flight.add(job_id)
+        result = await handler.handle_event(event, context)
+
+        assert result is None
+        assert handler.process_calls == 0
+        api_client.get_job_detail.assert_not_awaited()
+        api_client.start_job.assert_not_awaited()
+
+    async def test_transient_get_job_detail_failure_then_duplicate_proceeds(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        api_client.get_job_detail = AsyncMock(side_effect=httpx.ConnectError("boom"))
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+
+        # id stranded in neither set -> a later replay can proceed.
+        assert job_id not in handler._in_flight
+        assert job_id not in handler._seen
+
+        api_client.get_job_detail = AsyncMock(return_value={"payload": {"name": "alice"}})
+        await handler.handle_event(event, context)
+        api_client.start_job.assert_awaited_once()
+        assert handler.process_calls == 1
+
+    async def test_transient_start_job_failure_then_duplicate_proceeds(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        api_client.start_job = AsyncMock(side_effect=httpx.ConnectError("boom"))
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+
+        assert job_id not in handler._in_flight
+        assert job_id not in handler._seen
+
+        api_client.start_job = AsyncMock(return_value={})
+        await handler.handle_event(event, context)
+        assert handler.process_calls == 1
+        api_client.complete_job.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Payload validation -> cancel (AC-3)
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadValidation:
+    async def test_invalid_payload_cancels_and_does_not_start(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        session_id: UUID,
+        job_id: UUID,
+    ) -> None:
+        api_client.get_job_detail = AsyncMock(return_value={"payload": {"wrong": "field"}})
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        result = await handler.handle_event(event, context)
+
+        assert result is None
+        api_client.start_job.assert_not_awaited()
+        assert handler.process_calls == 0
+        api_client.cancel_job.assert_awaited_once()
+        _, kwargs = api_client.cancel_job.call_args
+        assert "reason" in kwargs
+
+
+# ---------------------------------------------------------------------------
+# process() error -> status mapping (AC-3)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessErrorMapping:
+    async def test_value_error_completes_with_failed_result(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise ValueError("bad business input")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        result = await handler.handle_event(event, context)
+
+        assert result is None
+        api_client.complete_job.assert_awaited_once()
+        _, kwargs = api_client.complete_job.call_args
+        assert kwargs["result"]["status"] == "failed"
+        assert "bad business input" in kwargs["result"]["error"]
+        api_client.cancel_job.assert_not_awaited()
+
+    async def test_generic_exception_completes_with_failed_result(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise RuntimeError("kaboom")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        await handler.handle_event(event, context)
+
+        api_client.complete_job.assert_awaited_once()
+        _, kwargs = api_client.complete_job.call_args
+        assert kwargs["result"]["status"] == "failed"
+
+    async def test_oserror_raises_retryable_and_leaves_pending(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise OSError("disk gone")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+
+        api_client.complete_job.assert_not_awaited()
+        api_client.cancel_job.assert_not_awaited()
+
+    async def test_invalid_event_error_from_process_cancels(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise InvalidEventError(status="bad", reason="unprocessable")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        result = await handler.handle_event(event, context)
+
+        assert result is None
+        api_client.cancel_job.assert_awaited_once()
+        api_client.complete_job.assert_not_awaited()
+
+    async def test_retryable_from_process_propagates(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise RetryableHandlerError(status="busy", reason="try later")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+        api_client.complete_job.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# complete_job retry / exhaustion (AC-3)
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteRetry:
+    async def test_complete_retries_then_succeeds(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        api_client.complete_job = AsyncMock(side_effect=[httpx.ConnectError("x"), httpx.ConnectError("y"), {}])
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        await handler.handle_event(event, context)
+
+        assert api_client.complete_job.await_count == 3
+
+    async def test_complete_exhaustion_raises_retryable(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        api_client.complete_job = AsyncMock(side_effect=httpx.ConnectError("always"))
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+        assert api_client.complete_job.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# HTTP status errors must propagate raw, NOT be wrapped as RetryableHandlerError.
+# SessionsBus catches RetryableHandlerError *before* httpx.HTTPStatusError, so
+# wrapping a 403 would swallow its session-key-refresh-and-retry recovery.
+# ---------------------------------------------------------------------------
+
+
+class TestHttpStatusErrorPropagation:
+    async def test_get_job_detail_403_propagates_unwrapped(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        api_client.get_job_detail = AsyncMock(side_effect=_http_status_error(403))
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await handler.handle_event(event, context)
+        # Not started, and the id is stranded in neither set so SessionsBus can retry.
+        api_client.start_job.assert_not_awaited()
+        assert job_id not in handler._in_flight
+        assert job_id not in handler._seen
+
+    async def test_start_job_403_propagates_unwrapped(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        api_client.start_job = AsyncMock(side_effect=_http_status_error(403))
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await handler.handle_event(event, context)
+        assert job_id not in handler._in_flight
+        assert job_id not in handler._seen
+
+    async def test_complete_job_status_error_propagates_without_retry(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        api_client.complete_job = AsyncMock(side_effect=_http_status_error(403))
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await handler.handle_event(event, context)
+        # Status errors are not transient — no pointless retry loop.
+        assert api_client.complete_job.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# CriticalHandlerError must keep its restart intent (not be neutralised into a
+# complete-with-error result by the generic Exception bucket).
+# ---------------------------------------------------------------------------
+
+
+class TestCriticalHandlerError:
+    async def test_critical_error_propagates(
+        self, mock_config: MagicMock, mock_registry: MagicMock, event: GenericCloudEvent, context: dict[str, Any], api_client: MagicMock
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise CriticalHandlerError(status="fatal", reason="restart me")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(CriticalHandlerError):
+            await handler.handle_event(event, context)
+        api_client.complete_job.assert_not_awaited()
+        api_client.cancel_job.assert_not_awaited()

--- a/tests/unit/agents/handler/test_sessions_job_handler.py
+++ b/tests/unit/agents/handler/test_sessions_job_handler.py
@@ -1,9 +1,10 @@
 """Unit tests for SessionsJobHandler (issue #19).
 
 Covers the shared job-lifecycle base: happy path, two-stage idempotency
-(in-flight guard + post-start seen-set), anti-stranding on transient pre-start
-failures, payload validation -> cancel, the process() error->status mapping,
-complete_job retry/exhaustion, and unknown-job_type no-op.
+(in-flight guard + terminal-only seen-set), eligibility-for-redelivery on
+transient pre-start AND post-start failures, payload validation -> cancel, the
+process() error->status mapping, complete_job retry/exhaustion, and
+unknown-job_type no-op.
 
 All svc-sessions calls are mocked; these tests do NOT prove the live cancel path
 (svc-sessions exposes no /cancel route — tracked as a separate follow-up).
@@ -513,3 +514,177 @@ class TestCriticalHandlerError:
             await handler.handle_event(event, context)
         api_client.complete_job.assert_not_awaited()
         api_client.cancel_job.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Terminal-only seen-set: a job that STARTED but did not reach a terminal state
+# (post-start retryable/critical failure) must stay out of `_seen`, so it is
+# eligible for redelivery rather than silently ignored. `_seen` is populated
+# only on terminal outcomes (complete / cancel / error-result-complete).
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalSeenSemantics:
+    async def test_retryable_from_process_leaves_job_unseen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise RetryableHandlerError(status="busy", reason="later")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+        api_client.start_job.assert_awaited_once()
+        assert job_id not in handler._seen
+        assert job_id not in handler._in_flight
+
+    async def test_oserror_from_process_leaves_job_unseen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise OSError("disk gone")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+        assert job_id not in handler._seen
+
+    async def test_timeout_error_from_process_leaves_job_unseen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise TimeoutError("slow")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+        assert job_id not in handler._seen
+
+    async def test_critical_from_process_leaves_job_unseen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise CriticalHandlerError(status="fatal", reason="restart")
+
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        with pytest.raises(CriticalHandlerError):
+            await handler.handle_event(event, context)
+        assert job_id not in handler._seen
+
+    async def test_complete_exhaustion_leaves_job_unseen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        api_client.complete_job = AsyncMock(side_effect=httpx.ConnectError("always"))
+        handler = _started(mock_config)
+        await handler.on_startup()
+
+        with pytest.raises(RetryableHandlerError):
+            await handler.handle_event(event, context)
+        assert job_id not in handler._seen
+
+    async def test_terminal_outcomes_populate_seen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        # Successful completion is terminal -> seen.
+        handler = _started(mock_config)
+        await handler.on_startup()
+        await handler.handle_event(event, context)
+        assert job_id in handler._seen
+
+    async def test_cancel_is_terminal_and_seen(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        api_client.get_job_detail = AsyncMock(return_value={"payload": {"wrong": "field"}})
+        handler = _started(mock_config)
+        await handler.on_startup()
+        await handler.handle_event(event, context)
+        assert job_id in handler._seen
+        # Replay of a cancelled job is a no-op (no second cancel).
+        await handler.handle_event(event, context)
+        api_client.cancel_job.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Error-result completion shares the retry helper with the success path.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResultCompletionRetry:
+    async def test_error_result_completion_retries_transient(
+        self,
+        mock_config: MagicMock,
+        mock_registry: MagicMock,
+        event: GenericCloudEvent,
+        context: dict[str, Any],
+        api_client: MagicMock,
+        job_id: UUID,
+    ) -> None:
+        async def boom(_p: Any, _c: Any) -> _Result:
+            raise ValueError("bad input")
+
+        # First complete attempt fails transiently, second succeeds.
+        api_client.complete_job = AsyncMock(side_effect=[httpx.ConnectError("x"), {}])
+        handler = _Handler(process_impl=boom)
+        mock_config.get.return_value = {"agent_id": "test-agent"}
+        await handler.on_startup()
+
+        await handler.handle_event(event, context)
+
+        assert api_client.complete_job.await_count == 2
+        _, kwargs = api_client.complete_job.call_args
+        assert kwargs["result"]["status"] == "failed"
+        assert job_id in handler._seen


### PR DESCRIPTION
Closes #19.

## Summary

Promotes the duplicated sessions job-lifecycle wrapper into a shared framework base, `blueprint.agents.handler.SessionsJobHandler`. Subclasses set `JOB_TYPE`/`PAYLOAD_MODEL`/`RESULT_MODEL` and implement one `process()` method; the base owns fetch → validate → start → process → complete. Additive — `EventHandlerBase` is unchanged.

Spec/plan: `docs/plans/2026-06-10-sessions-job-handler.md` (approved on #19; see its Amendment for the final idempotency model).

## Key behaviours

- **Two-stage idempotency:** in-flight guard (concurrent duplicates) + a **terminal-only** seen-set populated only on a terminal outcome (complete / cancel / error-result complete). A job that fails *before* a terminal state — transient fetch/start error **or** a post-start retryable/critical failure — stays in neither set, so it is left eligible for redelivery rather than silently dropped.
- **Error → terminal-state mapping** (verified: svc-sessions can only reach COMPLETED/CANCELLED; `FAILED` is unreachable): `InvalidEventError` → cancel; `ValueError`/generic `Exception` → complete with error-shaped result (shared retry helper); `RetryableHandlerError`/`OSError`/`TimeoutError` → re-raised, left eligible for redelivery.
- **Preserves SessionsBus 403 recovery:** only `httpx.RequestError` (transport) is wrapped; `HTTPStatusError` propagates raw so SessionsBus's session-key-refresh-and-retry still fires. `CriticalHandlerError` keeps its restart semantics.
- `complete_job` retry: 3×, 2s backoff, transport errors only; shared by success and error-result completion.

### Post-start retry — known bound

Eligible-for-redelivery is **not** the same as fully *resumable*. Verified svc-sessions `_VALID_TRANSITIONS` has no `RUNNING→RUNNING`, so once `start_job` ran, a redelivery re-calls `start_job` and gets a **409**. Post-start retryable failures are therefore no longer silently ignored, but true resume needs a svc-sessions re-pend/lease capability — tracked in bechtleav360/avs.ai.idac.service-sessions#59. An idempotent "swallow 409-already-running" start was rejected (under multi-replica SSE it would cause double-`process()`).

## Tests

30 unit tests: happy path, both idempotency stages, pre- and post-start redelivery-eligibility, payload→cancel, the full error-mapping matrix, 403 propagation on fetch/start/complete, CriticalHandlerError, success + error-result completion retry/exhaustion. Full unit suite: 886 passed. `ruff`/`black`/`mypy` clean.

## Notes / follow-ups

- No `pyproject.toml` version bump (per `AGENTS.md`, publishing owns versioning); CHANGELOG entry under `[0.6.0]`.
- **Follow-up (svc-sessions #59):** missing `/cancel` route + no post-start resume/re-pend path. Unit tests mock the client; they do not prove live cancel or resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
