### PR TITLE
fix(app_builder): read app title/version/description from config (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
   awaits a re-pend/lease capability there (avs.ai.idac.service-sessions#59).
   Additive and backwards compatible — `EventHandlerBase` is unchanged.
 
+### Fixed
+- **OpenAPI app metadata now comes from config** (#11). `AppBuilder.build()` no longer
+  hardcodes `version="0.1.0"`; it reads `app_version` (fallback `"0.0.0"`) alongside
+  `app_name` (fallback `"blueprint-service"`) and `app_description` (fallback `""`). The
+  misleading framework-internal description fallback is removed. Set `app_version` in a
+  service's `settings.toml` to surface the real version at `/docs`.
+
 ## [0.5.0] - 2026-03-05
 
 ### Architecture Refactoring - Component System Streamlining

--- a/src/blueprint/agents/app_builder.py
+++ b/src/blueprint/agents/app_builder.py
@@ -210,12 +210,9 @@ class AppBuilder:
 
         # 5. Build FastAPI app
         app = FastAPI(
-            title=self._config.get("app_name", "bios-agent"),
-            description=self._config.get(
-                "app_description",
-                "Generic microservice blueprint for building intelligent agents",
-            ),
-            version="0.1.0",
+            title=self._config.get("app_name", "blueprint-service"),
+            description=self._config.get("app_description", ""),
+            version=self._config.get("app_version", "0.0.0"),
             lifespan=self._create_lifespan_manager(),
             docs_url="/docs",
             redoc_url="/redoc",

--- a/tests/unit/agents/app_builder/test_app_builder.py
+++ b/tests/unit/agents/app_builder/test_app_builder.py
@@ -395,3 +395,49 @@ class TestBuildNatsRegression:
         all_build_mocks.nats_client.assert_called_once_with()
         all_build_mocks.nats_eventing.assert_called_once_with()
         all_build_mocks.sessions_bus.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# build() — OpenAPI app metadata sourced from config (#11)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAppMetadata:
+    def test_reads_title_version_description_from_config(
+        self,
+        builder_for_build: AppBuilder,
+        mock_registry: MagicMock,
+        all_build_mocks: types.SimpleNamespace,
+        build_config: MagicMock,
+    ) -> None:
+        wire_empty_registry(mock_registry)
+        values = {
+            "app_name": "svc-sessions",
+            "app_version": "0.2.0",
+            "app_description": "Secure session management service.",
+        }
+        build_config.get.side_effect = lambda key, default="": values.get(key, default)
+
+        builder_for_build.build()
+
+        _, kwargs = all_build_mocks.fastapi.call_args
+        assert kwargs["title"] == "svc-sessions"
+        assert kwargs["version"] == "0.2.0"
+        assert kwargs["description"] == "Secure session management service."
+
+    def test_version_falls_back_to_0_0_0_not_hardcoded(
+        self,
+        builder_for_build: AppBuilder,
+        mock_registry: MagicMock,
+        all_build_mocks: types.SimpleNamespace,
+        build_config: MagicMock,
+    ) -> None:
+        wire_empty_registry(mock_registry)
+        # Honour the default arg so we observe the fallback the code requests.
+        build_config.get.side_effect = lambda key, default=None: default
+
+        builder_for_build.build()
+
+        _, kwargs = all_build_mocks.fastapi.call_args
+        assert kwargs["version"] == "0.0.0"
+        assert kwargs["description"] == ""


### PR DESCRIPTION
Closes #11.

## Summary

`AppBuilder.build()` hardcoded `version="0.1.0"` and used framework-internal fallback strings, so every service's `/docs` (OpenAPI UI) showed stale/misleading metadata regardless of its own `settings.toml`.

## Fix

`build()` now sources all three from config:

| field | config key | fallback |
|---|---|---|
| `title` | `app_name` | `"blueprint-service"` (was `"bios-agent"`) |
| `description` | `app_description` | `""` (was the framework's own description) |
| `version` | `app_version` | `"0.0.0"` (was hardcoded `"0.1.0"`) |

Services set their real version in `settings.toml`:

```toml
app_name = "svc-sessions"
app_version = "0.2.0"
app_description = "Secure session management service."
```

## Tests

2 new unit tests (TDD): metadata read from config; `app_version` fallback is `0.0.0`, not the old hardcoded constant. Full unit suite: 888 passed. `ruff`/`black`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
