### PR TITLE
fix(cli): use sys.executable in asbs dev subprocess (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   `app_name` (fallback `"blueprint-service"`) and `app_description` (fallback `""`). The
   misleading framework-internal description fallback is removed. Set `app_version` in a
   service's `settings.toml` to surface the real version at `/docs`.
+- **`asbs dev` now uses the launching interpreter** (#15). The dev server subprocess
+  spawned `"python"` literally, which on Windows with uv-managed venvs could resolve to
+  uv's base interpreter and fail with `No module named uvicorn`. It now uses
+  `sys.executable`, so the reload server runs in the same venv as `asbs`.
 
 ## [0.5.0] - 2026-03-05
 

--- a/src/blueprint/agent_generator/cli/commands/dev.py
+++ b/src/blueprint/agent_generator/cli/commands/dev.py
@@ -26,9 +26,12 @@ def run(args: Namespace) -> None:
     print()
 
     try:
-        # Run uvicorn with reload
+        # Run uvicorn with reload. Use sys.executable (the interpreter that launched
+        # asbs) rather than a literal "python": on Windows with uv-managed venvs the
+        # latter can resolve to the base interpreter, which can't see the venv's
+        # site-packages (#15).
         cmd = [
-            "python",
+            sys.executable,
             "-m",
             "uvicorn",
             "src.main:app",

--- a/tests/unit/agent_generator/cli/commands/test_dev.py
+++ b/tests/unit/agent_generator/cli/commands/test_dev.py
@@ -1,0 +1,27 @@
+"""Unit tests for the `asbs dev` command (issue #15)."""
+
+import sys
+from argparse import Namespace
+from unittest.mock import patch
+
+from blueprint.agent_generator.cli.commands import dev
+
+
+class TestRunInterpreter:
+    def test_spawns_uvicorn_with_sys_executable_not_literal_python(self) -> None:
+        """The subprocess must use the launching interpreter (venv-correct on Windows),
+        not the literal "python" which can resolve to uv's base interpreter."""
+        args = Namespace(host="127.0.0.1", port=8000)
+        with (
+            patch("blueprint.agent_generator.cli.commands.dev.Path") as mock_path,
+            patch("blueprint.agent_generator.cli.commands.dev.subprocess.run") as mock_run,
+        ):
+            mock_path.return_value.exists.return_value = True
+            dev.run(args)
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == sys.executable
+        assert cmd[0] != "python"
+        assert cmd[1:4] == ["-m", "uvicorn", "src.main:app"]
+        assert "--reload" in cmd
+        assert cmd[-4:] == ["--host", "127.0.0.1", "--port", "8000"]


### PR DESCRIPTION
Closes #15.

## Summary

`asbs dev` failed with `No module named uvicorn` on Windows under uv-managed venvs, even after `uv sync --extra dev`.

## Root cause

`dev.py` spawned the reload server with a literal `"python"`:

```python
cmd = ["python", "-m", "uvicorn", "src.main:app", ...]
```

On Windows, `"python"` resolves via PATH and — with uv's relocatable launchers — can hit uv's **base** interpreter instead of the venv's. The base interpreter can't see the venv `site-packages`, so `uvicorn` (and everything `uv sync` installed) is invisible.

## Fix

Use `sys.executable` — the interpreter that launched `asbs` — so the subprocess runs in the same venv (PEP 394 portable pattern). `sys` was already imported; one-line change.

## Tests

New unit test (TDD): `asbs dev` builds the uvicorn command with `cmd[0] == sys.executable` (not `"python"`), with `subprocess.run`/`Path` mocked. Full unit suite: 889 passed. `ruff`/`black`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
