### PR TITLE
style: black formatting + mypy strict fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avs-blueprint-agents"
-version = "0.6.2"
+version = "0.6.3"
 description = "Microservice blueprint for creating agents"
 authors = [
     { name = "Blueprint Team", email = "patrick.maue@bechtle.com" },

--- a/tests/unit/agents/config/test_agent_scope.py
+++ b/tests/unit/agents/config/test_agent_scope.py
@@ -50,8 +50,7 @@ class TestBackwardCompatibility:
         assert base_config.get("app_port") == 8000
 
     def test_unscoped_get_runtime_config_uses_legacy_block(self, write_settings: WriteSettings) -> None:
-        settings_file = write_settings(
-            """
+        settings_file = write_settings("""
             [development]
             app_name = "legacy"
             app_port = 8000
@@ -62,8 +61,7 @@ class TestBackwardCompatibility:
 
             [development.runtimes.my_agent]
             model_name = "legacy-model"
-            """
-        )
+            """)
         config = Config(settings_files=[str(settings_file)], root_path=str(settings_file.parent))
         runtime_cfg = config.get_runtime_config("my_agent")
         assert runtime_cfg["model_name"] == "legacy-model"
@@ -110,16 +108,14 @@ class TestGetAiConfigScoped:
 
 class TestValidators:
     def test_missing_scoped_app_name_raises(self, write_settings: WriteSettings) -> None:
-        settings_file = write_settings(
-            """
+        settings_file = write_settings("""
             [development]
             app_environment = "development"
 
             [development.foo]
             app_port = 8101
             # app_name intentionally missing
-            """
-        )
+            """)
         with pytest.raises(ConfigError):
             Config(
                 settings_files=[str(settings_file)],
@@ -128,16 +124,14 @@ class TestValidators:
             )
 
     def test_missing_scoped_app_port_raises(self, write_settings: WriteSettings) -> None:
-        settings_file = write_settings(
-            """
+        settings_file = write_settings("""
             [development]
             app_environment = "development"
 
             [development.foo]
             app_name = "foo-app"
             # app_port intentionally missing
-            """
-        )
+            """)
         with pytest.raises(ConfigError):
             Config(
                 settings_files=[str(settings_file)],
@@ -147,16 +141,14 @@ class TestValidators:
 
     def test_root_keys_not_required_when_scoped(self, write_settings: WriteSettings) -> None:
         # No root app_name / app_port; only scoped versions exist.
-        settings_file = write_settings(
-            """
+        settings_file = write_settings("""
             [development]
             app_environment = "development"
 
             [development.foo]
             app_name = "foo-app"
             app_port = 8101
-            """
-        )
+            """)
         # Must not raise.
         config = Config(
             settings_files=[str(settings_file)],


### PR DESCRIPTION
Lint/static-analysis cleanup surfaced by a full `ruff` + `black` + `mypy` audit. No behavior changes.

## Changes
- **black**: reformat 5 files to the configured 140-char / py313 style (`config/config.py`, `io/api/actuators/actuator_api.py`, and 3 test files). Formatting only — AST-equivalent, verified on Python 3.13.
- **mypy (strict)**: `io/api/utilities/root.py` — `route.methods` is typed `set[str] | None` (Starlette); it was used unguarded by `sorted()` and `in`. Now guarded via `route.methods or set()`, resolving the 2 strict-mode errors.

## Verification
- `ruff check src/ tests/` — pass (was already clean)
- `black --check src/ tests/` (py313) — pass
- `mypy src/` — `Success: no issues found in 102 source files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVGErowPdRFzkNuiWmLaNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVGErowPdRFzkNuiWmLaNm)_