### PR TITLE
ci: fix stale venv cache breaking mypy/test steps

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -18,6 +18,7 @@ runs:
       uses: astral-sh/setup-uv@v6
 
     - name: Set up Python ${{ inputs.python-version }}
+      id: setup-python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
@@ -27,10 +28,15 @@ runs:
       id: cache-venv
       with:
         path: .venv
-        key: venv-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+        # Key on the resolved patch version (e.g. 3.13.14), not just "3.13".
+        # A venv's bin/ scripts hard-code the interpreter path; when the runner
+        # bumps its 3.13.x patch the old cached interpreter disappears and the
+        # restored scripts fail with "cannot execute: required file not found".
+        key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
 
     - name: Create venv and install dependencies
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # Always run: idempotent with uv, and it repairs a restored venv whose
+      # interpreter path drifted. On a clean cache hit this is a fast no-op.
       shell: bash
       run: |
         uv venv .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avs-blueprint-agents"
-version = "0.6.1"
+version = "0.6.2"
 description = "Microservice blueprint for creating agents"
 authors = [
     { name = "Blueprint Team", email = "patrick.maue@bechtle.com" },

--- a/src/blueprint/agents/io/api/utilities/root.py
+++ b/src/blueprint/agents/io/api/utilities/root.py
@@ -45,9 +45,10 @@ class RootApi(RestApiBase):
         for route in self._app.routes:
             if not isinstance(route, APIRoute):
                 continue
-            methods = ", ".join(sorted(route.methods))
+            route_methods = route.methods or set()
+            methods = ", ".join(sorted(route_methods))
             summary = route.summary or ""
-            if "GET" in route.methods:
+            if "GET" in route_methods:
                 path_cell = f'<a href="{route.path}">{route.path}</a>'
             else:
                 anchor = route.path.replace("/", "-").strip("-")


### PR DESCRIPTION
## Problem

CI (`Lint, Type Check & Test`) fails at the **mypy** step on every branch — and would on `develop` too — with:

```
.venv/bin/mypy: cannot execute: required file not found   (exit 127)
```

Root cause is in `.github/actions/setup-python-env`:

- The `.venv` cache key uses the **major** Python version (`py3.13`) + `hash(pyproject.toml)` — it omits the patch version.
- The venv is only rebuilt **on a cache miss** (`if: cache-hit != 'true'`).

A venv's `bin/` entrypoints hard-code the absolute interpreter path. The cache was last built weeks ago (last green `develop` run: 2026-06-11); since then the runner bumped its 3.13.x patch (now **3.13.14**), so the cached interpreter path no longer exists. The restored venv is reused as-is and its scripts can't execute. `ruff` escapes this because it runs as a standalone PATH binary (via `setup-uv`), not through a venv shebang — which is why only the mypy step fails.

## Fix (2 commits)

**1. CI — `setup-python-env`:**
- **Key the cache on the resolved patch version** (`steps.setup-python.outputs.python-version`, e.g. `3.13.14`) so a patch bump busts the cache and rebuilds the venv.
- **Always run the install step** (idempotent with `uv`) so a restored venv whose interpreter drifted is repaired rather than used as-is. On a clean cache hit this is a fast no-op.

**2. `root.py` mypy guard** (one line): once the venv fix lets mypy actually run, it surfaces a **pre-existing** type error on `develop` that the broken cache had been masking — `route.methods` is typed `set[str] | None` (Starlette) and was used unguarded by `sorted()` and `in`. Guarded via `route.methods or set()`. The same fix is also in the lint PR #37 (which rebases cleanly once this lands).

## Verification

Run locally against the exact CI steps — all green:
- `ruff check src tests` ✅
- `ruff format --check src tests` ✅
- `mypy src` → `Success: no issues found in 102 source files` ✅

## Impact

Unblocks CI repo-wide. Once merged, the two lint-cleanup PRs (#37, and the sibling cleanup in `service-sessions` #86) can go green. Scope is the CI composite action plus one defensive one-liner that mypy now requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVGErowPdRFzkNuiWmLaNm