### PR TITLE
fix(openapi): drop the blanket `rest` tag from business REST routers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-06
+
+### Changed
+- **Business REST routers no longer carry a blanket `rest` OpenAPI tag.** `_build_rest_endpoints` mounted every `with_rest_api` router with `include_router(..., tags=["rest"])`, which stamps a redundant `rest` tag onto *every* operation on top of its own per-operation tag — so the entire business API collapses into a single `rest` group in Swagger UI. Routers are now mounted without the blanket tag; operations group by their real resource tags (set via the `RestApiBase` decorators), and untagged routes fall under FastAPI's `default`. Presentation only — no route/path/schema change. Downstream services that relied on the `rest` grouping should tag their routes (most already do).
+
 ## [0.6.1] - 2026-06-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avs-blueprint-agents"
-version = "0.6.3"
+version = "0.6.4"
 description = "Microservice blueprint for creating agents"
 authors = [
     { name = "Blueprint Team", email = "patrick.maue@bechtle.com" },

--- a/src/blueprint/agents/app_builder.py
+++ b/src/blueprint/agents/app_builder.py
@@ -227,7 +227,12 @@ class AppBuilder:
         app.include_router(RootApi(app=app).router, tags=["root"])
 
         for rest_api in registry.get_rest_apis():
-            app.include_router(rest_api.router, prefix="/api", tags=["rest"])
+            # No blanket `tags=["rest"]`: it stamps every operation with a redundant "rest" tag on
+            # top of its own resource tag, so the whole business API collapses into one "rest" group
+            # in Swagger UI. Routes carry their per-operation tags (set via the RestApiBase decorators)
+            # and group correctly; untagged routes fall under FastAPI's "default", which is the nudge
+            # for services to tag their routes rather than hide behind a catch-all.
+            app.include_router(rest_api.router, prefix="/api")
 
         if self._eventing_component is not None:
             app.include_router(self._eventing_component.router)


### PR DESCRIPTION
## Problem
`AppBuilder._build_rest_endpoints` mounts every `with_rest_api` router with a blanket tag:

```python
app.include_router(rest_api.router, prefix="/api", tags=["rest"])
```

FastAPI *adds* router-level tags to every operation, so each business route ends up with a redundant `rest` tag on top of its own resource tag (`sessions`, `jobs`, …). In Swagger UI the entire business API therefore collapses into one giant `rest` group, on top of the real per-resource groups — noisy and hard to navigate.

## Change
Mount the routers without the blanket tag:

```python
app.include_router(rest_api.router, prefix="/api")
```

Operations now group by their real per-operation tags (set via the `RestApiBase` decorators). Untagged routes fall under FastAPI's `default` — a nudge for services to tag their routes rather than hide behind a catch-all.

**Presentation only** — no route, path, or schema change; the served endpoints are identical.

## Impact
Every service built on the blueprint gets a cleaner Swagger UI. Downstream services that leaned on the `rest` grouping should tag their routes (most already do via the decorators). Motivated by the OpenAPI cleanup in `avs.ai.idac.service-sessions` (svc-sessions #116 / PR #117), which currently strips this tag post-build as a shim — that shim can be removed once this releases and the pin is bumped.

## Tests
`tests/unit/agents/app_builder/test_app_builder.py` + `tests/unit/agents/io/api/test_rest_api_base.py` pass (55 tests); no test asserted the blanket `rest` tag. Bump `0.6.3` → `0.6.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
