### PR TITLE
fix(sessions): register with dispatch registry before opening SSE stream (#45, #44)

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -35,11 +35,12 @@ runs:
         key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
 
     - name: Create venv and install dependencies
-      # Always run: idempotent with uv, and it repairs a restored venv whose
-      # interpreter path drifted. On a clean cache hit this is a fast no-op.
+      # Always run: `--clear` recreates the venv, repairing a restored one whose
+      # interpreter path drifted AND tolerating a cache hit that already placed
+      # `.venv` (plain `uv venv` aborts with "a virtual environment already exists").
       shell: bash
       run: |
-        uv venv .venv
+        uv venv .venv --clear
         uv pip install -e ".[${{ inputs.install-extras }}]"
 
     - name: Add venv to PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **`SessionsBus` registers with the dispatch registry before opening the SSE stream** (#45).
+  Sessions v0.4.0 gates `GET /jobs/stream/sse` on a prior `POST /agents/register`; the bus now
+  registers (idempotent) before every connect attempt and re-registers on reconnect, fixing the
+  403 loop that broke all deployed agents. A pre-v0.4.0 server (404 on register) is handled as
+  "legacy, proceed without registration". The real status/body of an SSE rejection is now logged
+  instead of an opaque `SSEError`.
+- **Keepalive comment frames are no longer logged as `Unknown SSE event type: message`** (#44).
+
+### Changed
+- **`SessionsBus` unregisters and drains in-flight jobs on graceful shutdown.** It stops the stream,
+  waits for in-flight jobs (bounded by `job_timeout_seconds`, cancelling stragglers), then calls
+  `DELETE /agents/{agent_id}` so the agent leaves the registry immediately instead of lapsing at TTL.
+- Job notifications are parsed into a typed `JobNotification` model at the SSE boundary.
+
 ## [0.6.1] - 2026-06-10
 
 ### Added

--- a/docs/concepts/event-processing.md
+++ b/docs/concepts/event-processing.md
@@ -244,6 +244,12 @@ When `event_bus = "sessions"`, `AppBuilder.build()` wires three components autom
 
 `SessionsBus` has no inbound HTTP surface — there is no router to mount. Connection to the sessions service is established asynchronously after startup; the framework tolerates a sessions service that is unreachable at boot and retries in the background.
 
+> **Agent registration (sessions v0.4.0+):** Before opening the SSE job stream, `SessionsBus` calls
+> `POST /agents/register` to declare its `agent_id`, `agent_type`, and `capabilities` — the dispatch
+> source of truth. It re-registers before every reconnect attempt (idempotent), and on graceful
+> shutdown it drains in-flight jobs and unregisters (`DELETE /agents/{agent_id}`). Against a pre-v0.4.0
+> server the register call returns 404 and is skipped ("legacy, proceed without registration").
+
 ```toml
 [default]
 event_bus = "sessions"

--- a/docs/superpowers/plans/2026-07-06-sessions-agent-registration.md
+++ b/docs/superpowers/plans/2026-07-06-sessions-agent-registration.md
@@ -1,0 +1,1143 @@
+# SessionsBus Agent Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `SessionsBus` register with the sessions v0.4.0 dispatch registry before opening the SSE stream (and re-register on every reconnect, unregister on shutdown), fixing the 403 gate that breaks all deployed agents; also silence #44 keepalive log noise.
+
+**Architecture:** Registration is a new pair of methods on `SessionsApiClient` (`register_agent`/`unregister_agent`), built on a new shared `_request` helper. `SessionsBus._connect_and_consume` calls `register_agent` before opening the stream so the reconnect/backoff loop retries registration for free. Job notifications are modelled as a `JobNotification` value object parsed once at the SSE boundary; the job-processing method is split into a thin dispatcher plus per-policy helpers with a single dispatch seam. `on_shutdown` drains in-flight jobs, then unregisters.
+
+**Tech Stack:** Python 3.12+, httpx / httpx-sse, pydantic v2, pytest (async), OpenTelemetry. Line length 140. Quality gate: `black`, `ruff`, `mypy`.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md`. Closes #45 and #44.
+
+**Branch:** work on `feature/sessions-agent-registration` (already created). **All commits end with the repo's standard trailer** (`Co-Authored-By: Claude Opus 4.8 (1M context) …` + `Claude-Session: …`) — append it to every commit message; it is omitted from the command examples below only for brevity.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/blueprint/agents/services/sessions/api_client.py` | HTTP client for the sessions REST API | Add `_request`, migrate 4 methods, add `register_agent`/`unregister_agent` |
+| `src/blueprint/agents/models/sessions.py` | Sessions domain models | **Create** — `JobNotification` value object |
+| `src/blueprint/agents/io/api/eventing/sessions_bus.py` | SSE consumer / job dispatcher | Register-before-connect, SSE event dispatch split, JobNotification threading, shutdown drain |
+| `tests/unit/agents/services/sessions/conftest.py` | api_client test fixtures | Add `delete` to `mock_http_client` |
+| `tests/unit/agents/services/sessions/test_api_client.py` | api_client unit tests | New tests for register/unregister |
+| `tests/unit/agents/models/test_sessions.py` | model unit tests | **Create** |
+| `tests/unit/agents/io/api/eventing/test_sessions_bus.py` | bus unit tests | New + updated tests |
+| `CHANGELOG.md`, `docs/concepts/event-processing.md` | docs | Add entries |
+
+---
+
+## Task 1: `SessionsApiClient._request` helper + migrate existing methods (Refactor #1)
+
+Behaviour-preserving extraction. The existing api_client tests are the regression guard — they must stay green **unchanged**.
+
+**Files:**
+- Modify: `src/blueprint/agents/services/sessions/api_client.py`
+- Test: `tests/unit/agents/services/sessions/test_api_client.py` (existing, unchanged)
+
+- [ ] **Step 1: Run the existing api_client tests to confirm the green baseline**
+
+Run: `uv run pytest tests/unit/agents/services/sessions/test_api_client.py -v`
+Expected: PASS (all existing tests).
+
+- [ ] **Step 2: Add the `_request` helper**
+
+Add this method to `SessionsApiClient` (place it just after `on_shutdown`). `Any` is already imported.
+
+```python
+async def _request(
+    self,
+    method: str,
+    path: str,
+    *,
+    session_key: str | None = None,
+    json: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Issue an authenticated request to the sessions service.
+
+    Owns the client-initialised guard, URL assembly, and the optional
+    X-Session-Key header. Returns the raw Response so callers decide how to treat
+    status codes (registration branches on 404 rather than always raising).
+    """
+    if not self._client:
+        raise ValueError("SessionsApiClient not initialized. Call on_startup() first.")
+
+    url = f"{self._base_url}{path}"
+    kwargs: dict[str, Any] = {}
+    if session_key is not None:
+        kwargs["headers"] = {"X-Session-Key": session_key}
+    if json is not None:
+        kwargs["json"] = json
+
+    method_fn = getattr(self._client, method.lower())
+    return await method_fn(url, **kwargs)
+```
+
+- [ ] **Step 3: Migrate `start_job` to use `_request`**
+
+Replace the body of `start_job` (keep the signature and docstring) with:
+
+```python
+    logger.info("Starting job: session_id=%s, job_id=%s, agent_id=%s", session_id, job_id, agent_id)
+    response = await self._request(
+        "POST",
+        f"/sessions/{session_id}/jobs/{job_id}/start",
+        session_key=session_key,
+        json={"agent_id": agent_id},
+    )
+    response.raise_for_status()
+    job_data = response.json()
+    logger.info("Job started successfully: job_id=%s", job_id)
+    return job_data
+```
+
+- [ ] **Step 4: Migrate `get_job_detail` to use `_request`**
+
+```python
+    logger.debug("Fetching job detail: session_id=%s, job_id=%s", session_id, job_id)
+    response = await self._request(
+        "GET",
+        f"/sessions/{session_id}/jobs/{job_id}",
+        session_key=session_key,
+    )
+    response.raise_for_status()
+    job_data = response.json()
+    logger.debug("Job detail fetched: job_id=%s", job_id)
+    return job_data
+```
+
+- [ ] **Step 5: Migrate `complete_job` to use `_request`**
+
+```python
+    logger.info("Completing job: session_id=%s, job_id=%s", session_id, job_id)
+    response = await self._request(
+        "POST",
+        f"/sessions/{session_id}/jobs/{job_id}/complete",
+        session_key=session_key,
+        json={"result": result},
+    )
+    response.raise_for_status()
+    job_data = response.json()
+    logger.info("Job completed successfully: job_id=%s", job_id)
+    return job_data
+```
+
+- [ ] **Step 6: Migrate `cancel_job` to use `_request`**
+
+```python
+    payload = {"reason": reason} if reason else {}
+    logger.warning("Cancelling job: session_id=%s, job_id=%s, reason=%s", session_id, job_id, reason)
+    response = await self._request(
+        "POST",
+        f"/sessions/{session_id}/jobs/{job_id}/cancel",
+        session_key=session_key,
+        json=payload,
+    )
+    response.raise_for_status()
+    job_data = response.json()
+    logger.info("Job cancelled successfully: job_id=%s", job_id)
+    return job_data
+```
+
+- [ ] **Step 7: Run the existing tests to confirm they still pass**
+
+Run: `uv run pytest tests/unit/agents/services/sessions/test_api_client.py -v`
+Expected: PASS (unchanged) — `_request` dispatches to `client.post`/`client.get`, so the assertions on `.post`/`.get` call args still hold.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/blueprint/agents/services/sessions/api_client.py
+git commit -m "refactor(sessions): extract shared _request helper in SessionsApiClient"
+```
+
+---
+
+## Task 2: `SessionsApiClient.register_agent` (#45)
+
+**Files:**
+- Modify: `src/blueprint/agents/services/sessions/api_client.py`
+- Test: `tests/unit/agents/services/sessions/test_api_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_api_client.py`:
+
+```python
+import httpx
+
+
+class TestRegisterAgent:
+    async def test_posts_to_register_endpoint_with_body(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        await started_api_client.register_agent("agent-1", "analyser", ["classify"])
+        url = mock_http_client.post.call_args[0][0]
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert url.endswith("/agents/register")
+        assert payload == {"agent_id": "agent-1", "agent_type": "analyser", "capabilities": ["classify"]}
+
+    async def test_201_returns_true(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        assert await started_api_client.register_agent("a", "t", []) is True
+
+    async def test_200_returns_true(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 200
+        assert await started_api_client.register_agent("a", "t", []) is True
+
+    async def test_404_returns_false_and_does_not_raise(self, started_api_client, mock_http_client, caplog) -> None:
+        mock_http_client.post.return_value.status_code = 404
+        with caplog.at_level("WARNING"):
+            result = await started_api_client.register_agent("a", "t", [])
+        assert result is False
+        assert "legacy" in caplog.text.lower()
+        mock_http_client.post.return_value.raise_for_status.assert_not_called()
+
+    async def test_500_raises_and_logs_body(self, started_api_client, mock_http_client, caplog) -> None:
+        resp = mock_http_client.post.return_value
+        resp.status_code = 500
+        resp.text = "internal error detail"
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError("500", request=MagicMock(), response=resp)
+        with caplog.at_level("ERROR"), pytest.raises(httpx.HTTPStatusError):
+            await started_api_client.register_agent("a", "t", [])
+        assert "internal error detail" in caplog.text
+
+    async def test_optional_fields_included_when_given(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        await started_api_client.register_agent("a", "t", [], version="1.2.3", metadata={"k": "v"})
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert payload["version"] == "1.2.3"
+        assert payload["metadata"] == {"k": "v"}
+
+    async def test_raises_when_not_initialized(self, api_client) -> None:
+        with pytest.raises(ValueError, match="not initialized"):
+            await api_client.register_agent("a", "t", [])
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/unit/agents/services/sessions/test_api_client.py::TestRegisterAgent -v`
+Expected: FAIL with `AttributeError: 'SessionsApiClient' object has no attribute 'register_agent'`.
+
+- [ ] **Step 3: Implement `register_agent`**
+
+Add to `SessionsApiClient` (after `cancel_job`):
+
+```python
+async def register_agent(
+    self,
+    agent_id: str,
+    agent_type: str,
+    capabilities: list[str],
+    version: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Register the agent with the sessions dispatch registry (idempotent).
+
+    v0.4.0 gates ``GET /jobs/stream/sse`` on a prior registration. Returns True
+    when the server accepted it (200/201). Returns False when the server is a
+    legacy (< v0.4.0) instance without the endpoint (404) — the caller may still
+    open the stream. Raises on any other non-2xx so the reconnect loop backs off.
+    """
+    payload: dict[str, Any] = {"agent_id": agent_id, "agent_type": agent_type, "capabilities": capabilities}
+    if version is not None:
+        payload["version"] = version
+    if metadata:
+        payload["metadata"] = metadata
+
+    response = await self._request("POST", "/agents/register", json=payload)
+
+    if response.status_code == 404:
+        logger.warning("Sessions service has no /agents/register (legacy < v0.4.0); proceeding without registration")
+        return False
+
+    if response.status_code >= 400:
+        logger.error("Agent registration failed: status=%d body=%s", response.status_code, response.text)
+    response.raise_for_status()
+    logger.info("Agent registered: agent_id=%s (status=%d)", agent_id, response.status_code)
+    return True
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/unit/agents/services/sessions/test_api_client.py::TestRegisterAgent -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/blueprint/agents/services/sessions/api_client.py tests/unit/agents/services/sessions/test_api_client.py
+git commit -m "feat(sessions): add SessionsApiClient.register_agent (#45)"
+```
+
+---
+
+## Task 3: `SessionsApiClient.unregister_agent` (#45)
+
+**Files:**
+- Modify: `src/blueprint/agents/services/sessions/api_client.py`
+- Modify: `tests/unit/agents/services/sessions/conftest.py`
+- Test: `tests/unit/agents/services/sessions/test_api_client.py`
+
+- [ ] **Step 1: Add `delete` to the `mock_http_client` fixture**
+
+In `conftest.py`, inside `mock_http_client`, add after the `client.post` line:
+
+```python
+    client.delete = AsyncMock(return_value=mock_response)
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `test_api_client.py`:
+
+```python
+class TestUnregisterAgent:
+    async def test_deletes_agent_endpoint(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.delete.return_value.status_code = 204
+        await started_api_client.unregister_agent("agent-1")
+        url = mock_http_client.delete.call_args[0][0]
+        assert url.endswith("/agents/agent-1")
+
+    async def test_swallows_errors(self, started_api_client, mock_http_client, caplog) -> None:
+        mock_http_client.delete.side_effect = httpx.ConnectError("boom")
+        with caplog.at_level("WARNING"):
+            await started_api_client.unregister_agent("agent-1")  # must not raise
+        assert "unregister failed" in caplog.text.lower()
+
+    async def test_swallows_uninitialized_client(self, api_client) -> None:
+        await api_client.unregister_agent("agent-1")  # must not raise
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `uv run pytest tests/unit/agents/services/sessions/test_api_client.py::TestUnregisterAgent -v`
+Expected: FAIL with `AttributeError: … has no attribute 'unregister_agent'`.
+
+- [ ] **Step 4: Implement `unregister_agent`**
+
+Add to `SessionsApiClient` (after `register_agent`):
+
+```python
+async def unregister_agent(self, agent_id: str) -> None:
+    """Best-effort graceful deregistration (idempotent DELETE). Never raises.
+
+    Called on shutdown; a failure here must not prevent a clean shutdown, so all
+    exceptions (network error, 404 on legacy, closed client) are swallowed.
+    """
+    try:
+        response = await self._request("DELETE", f"/agents/{agent_id}")
+        logger.info("Agent unregistered: agent_id=%s (status=%d)", agent_id, response.status_code)
+    except Exception as e:
+        logger.warning("Graceful unregister failed for agent_id=%s: %s", agent_id, e)
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `uv run pytest tests/unit/agents/services/sessions/test_api_client.py::TestUnregisterAgent -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/blueprint/agents/services/sessions/api_client.py tests/unit/agents/services/sessions/conftest.py tests/unit/agents/services/sessions/test_api_client.py
+git commit -m "feat(sessions): add SessionsApiClient.unregister_agent (#45)"
+```
+
+---
+
+## Task 4: `JobNotification` value object (Refactor #4 — model)
+
+**Files:**
+- Create: `src/blueprint/agents/models/sessions.py`
+- Create: `tests/unit/agents/models/test_sessions.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/agents/models/test_sessions.py`:
+
+```python
+"""Unit tests for sessions domain models."""
+
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from blueprint.agents.models.sessions import JobNotification
+
+_VALID = {
+    "session_id": "00000000-0000-0000-0000-000000000001",
+    "job_id": "00000000-0000-0000-0000-000000000002",
+    "job_type": "transcription",
+    "created_at": "2024-01-01T00:00:00Z",
+}
+
+
+class TestJobNotification:
+    def test_parses_and_types_ids(self) -> None:
+        n = JobNotification.model_validate(_VALID)
+        assert n.session_id == UUID("00000000-0000-0000-0000-000000000001")
+        assert n.job_id == UUID("00000000-0000-0000-0000-000000000002")
+        assert n.job_type == "transcription"
+
+    def test_created_at_optional(self) -> None:
+        data = {k: v for k, v in _VALID.items() if k != "created_at"}
+        assert JobNotification.model_validate(data).created_at is None
+
+    def test_missing_required_field_raises(self) -> None:
+        data = {k: v for k, v in _VALID.items() if k != "job_id"}
+        with pytest.raises(ValidationError):
+            JobNotification.model_validate(data)
+
+    def test_extra_keys_preserved_in_payload(self) -> None:
+        n = JobNotification.model_validate({**_VALID, "priority": "high"})
+        payload = n.payload()
+        assert payload["priority"] == "high"
+        assert payload["session_id"] == _VALID["session_id"]  # UUID serialised back to str
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/unit/agents/models/test_sessions.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'blueprint.agents.models.sessions'`.
+
+- [ ] **Step 3: Create the model**
+
+Create `src/blueprint/agents/models/sessions.py`:
+
+```python
+"""Domain models for the sessions service integration."""
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class JobNotification(BaseModel):
+    """A job dispatch notification received over the sessions SSE stream.
+
+    Parsed once at the SSE boundary so field names and presence rules live in one
+    place instead of being read ad hoc as ``dict`` keys throughout the bus. Extra
+    keys in the payload are preserved (``extra="allow"``) and flow through to the
+    CloudEvent ``data``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    session_id: UUID
+    job_id: UUID
+    job_type: str
+    created_at: str | None = None
+
+    def payload(self) -> dict[str, Any]:
+        """The full notification as a JSON-serialisable dict (UUIDs as strings)."""
+        return self.model_dump(mode="json")
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/unit/agents/models/test_sessions.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/blueprint/agents/models/sessions.py tests/unit/agents/models/test_sessions.py
+git commit -m "feat(sessions): add JobNotification value object"
+```
+
+---
+
+## Task 5: SessionsBus — register before opening the SSE stream (#45 core)
+
+The headline fix, isolated in its own commit for reviewability and bisect. This inserts the register call at the top of `_connect_and_consume`; Task 6 later rewrites the rest of that method.
+
+**Files:**
+- Modify: `src/blueprint/agents/io/api/eventing/sessions_bus.py:155-169`
+- Test: `tests/unit/agents/io/api/eventing/test_sessions_bus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_sessions_bus.py` (inside a new class):
+
+```python
+class TestRegisterBeforeConnect:
+    async def test_registers_before_opening_stream(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._base_url = "http://sessions-svc"
+        bus._agent_id = "agent-001"
+        bus._agent_type = "transcription"
+        bus._capabilities = ["transcribe"]
+        bus._api_key = "secret"
+        bus._api_client.register_agent = AsyncMock(side_effect=RuntimeError("register-first"))
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse") as mock_sse:
+            with pytest.raises(RuntimeError, match="register-first"):
+                await bus._connect_and_consume()
+            mock_sse.assert_not_called()  # stream is never opened when registration fails
+
+        bus._api_client.register_agent.assert_awaited_once_with(
+            agent_id="agent-001", agent_type="transcription", capabilities=["transcribe"]
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py::TestRegisterBeforeConnect -v`
+Expected: FAIL — `register_agent` is not called before `aconnect_sse` (the mock IS called / no register).
+
+- [ ] **Step 3: Insert the register call at the top of `_connect_and_consume`**
+
+In `_connect_and_consume`, immediately after the docstring and before `url = f"{self._base_url}/jobs/stream/sse"`, add:
+
+```python
+        # v0.4.0 gates the stream on registration — register (idempotent) before every
+        # connect attempt. On a legacy server this is a no-op (404 -> False); on a hard
+        # failure it raises and the reconnect loop (in _consume_sse_stream) backs off.
+        await self._api_client.register_agent(
+            agent_id=self._agent_id,
+            agent_type=self._agent_type,
+            capabilities=self._capabilities,
+        )
+
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py::TestRegisterBeforeConnect -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full bus test file (nothing else should regress)**
+
+Run: `uv run pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/blueprint/agents/io/api/eventing/sessions_bus.py tests/unit/agents/io/api/eventing/test_sessions_bus.py
+git commit -m "fix(sessions): register with dispatch registry before opening SSE stream (#45)"
+```
+
+---
+
+## Task 6: SessionsBus — model notifications, split dispatch, keepalive + diagnostics (Refactors #2, #3, #4; #44)
+
+One atomic commit because threading the `JobNotification` value object touches producer (`_connect_and_consume`) and consumers (`_handle_job_notification`, `_process_job_notification`, `_convert_to_cloud_event`) together — splitting them would leave a type-inconsistent intermediate commit. If the team decides to defer the `JobNotification` change to a follow-up PR (per the spec's scope guard), the `_dispatch_cloud_event` unification and error-policy extraction can still be kept; the notification would stay a dict.
+
+**Files:**
+- Modify: `src/blueprint/agents/io/api/eventing/sessions_bus.py` (imports, `__init__`, `_connect_and_consume`, new `_dispatch_sse_event`, `_handle_job_notification`, `_process_job_notification` + new helpers, `_convert_to_cloud_event`)
+- Test: `tests/unit/agents/io/api/eventing/test_sessions_bus.py`
+
+### Implementation
+
+- [ ] **Step 1: Update imports**
+
+At the top of `sessions_bus.py`, change the httpx_sse import and add the model import:
+
+```python
+from httpx_sse import ServerSentEvent, SSEError, aconnect_sse
+```
+
+Add with the other model imports:
+
+```python
+from ....models.sessions import JobNotification
+```
+
+- [ ] **Step 2: Track in-flight job tasks in `__init__`**
+
+In `SessionsBus.__init__`, add after `self._shutdown_event: asyncio.Event = asyncio.Event()`:
+
+```python
+        # In-flight job tasks (tracked so shutdown can drain them, not orphan them)
+        self._inflight_tasks: set[asyncio.Task[None]] = set()
+```
+
+- [ ] **Step 3: Rewrite `_connect_and_consume`**
+
+Replace the whole method (from Task 5 it already has the register call at the top) with:
+
+```python
+    async def _connect_and_consume(self) -> None:
+        """Register, then establish the SSE connection and consume events."""
+        # v0.4.0 gates the stream on registration — register (idempotent) before every
+        # connect attempt. On a legacy server this is a no-op (404 -> False); on a hard
+        # failure it raises and the reconnect loop (in _consume_sse_stream) backs off.
+        await self._api_client.register_agent(
+            agent_id=self._agent_id,
+            agent_type=self._agent_type,
+            capabilities=self._capabilities,
+        )
+
+        url = f"{self._base_url}/jobs/stream/sse"
+        params: dict[str, Any] = {"agent_id": self._agent_id}
+        if self._agent_type:
+            params["agent_type"] = self._agent_type
+        if self._capabilities:
+            params["capabilities"] = ",".join(self._capabilities)
+
+        headers = {"X-Api-Key": self._api_key}
+
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with aconnect_sse(client, "GET", url, params=params, headers=headers) as event_source:
+                logger.info("SSE connection established")
+                try:
+                    async for sse in event_source.aiter_sse():
+                        if self._shutdown_event.is_set():
+                            break
+                        self._dispatch_sse_event(sse)
+                except SSEError:
+                    # aconnect_sse hides the real status when the server returns JSON (e.g. a
+                    # 403 dispatch-gate rejection). Surface status + body before backing off.
+                    resp = event_source.response
+                    body = (await resp.aread()).decode(errors="replace")[:500]
+                    logger.error("SSE stream rejected: status=%d body=%s", resp.status_code, body)
+                    raise
+```
+
+- [ ] **Step 4: Add `_dispatch_sse_event`**
+
+Add this method directly after `_connect_and_consume`:
+
+```python
+    def _dispatch_sse_event(self, sse: ServerSentEvent) -> None:
+        """Route a single SSE frame. Keepalive comment frames are ignored (#44)."""
+        try:
+            if sse.event == "connected":
+                logger.info("SSE connected event received")
+
+            elif sse.event == "job_created":
+                notification = JobNotification.model_validate_json(sse.data)
+                logger.info(
+                    "Job notification received: job_id=%s, job_type=%s",
+                    notification.job_id,
+                    notification.job_type,
+                )
+                task = asyncio.create_task(self._handle_job_notification(notification))
+                self._inflight_tasks.add(task)
+                task.add_done_callback(self._inflight_tasks.discard)
+
+            elif sse.event == "heartbeat":
+                logger.debug("SSE heartbeat received")
+
+            elif sse.event == "message" and not (sse.data or "").strip():
+                # Server keepalive comment frame (`: keepalive`) surfaces as a default-type
+                # `message` with empty data. Ignore it (#44) instead of warning every tick.
+                logger.debug("SSE keepalive frame received")
+
+            else:
+                logger.warning("Unknown SSE event type: %s", sse.event)
+
+        except Exception as e:
+            logger.error("Error processing SSE event: %s", e, exc_info=True)
+```
+
+- [ ] **Step 5: Update `_handle_job_notification` signature**
+
+Change the signature and the timeout log to take a `JobNotification`:
+
+```python
+    async def _handle_job_notification(self, notification: JobNotification) -> None:
+        """Handle job notification with concurrency control.
+
+        Args:
+            notification: Parsed job notification from the SSE stream
+        """
+        if self._semaphore is None:
+            raise RuntimeError("Semaphore not initialized")
+        async with self._semaphore:
+            try:
+                await asyncio.wait_for(
+                    self._process_job_notification(notification),
+                    timeout=self._job_timeout,
+                )
+            except TimeoutError:
+                logger.error(
+                    "Job processing timeout after %ds: job_id=%s",
+                    self._job_timeout,
+                    notification.job_id,
+                )
+```
+
+- [ ] **Step 6: Rewrite `_process_job_notification` as a thin dispatcher + add helpers**
+
+Replace the whole `_process_job_notification` method with the following, and add the four helper methods after it:
+
+```python
+    async def _process_job_notification(self, notification: JobNotification) -> None:
+        """Convert the notification to a CloudEvent and dispatch it, applying
+        sessions-specific error handling. Each recovery policy lives in its own
+        helper so this method stays a thin dispatcher.
+        """
+        session_id = notification.session_id
+        job_id = notification.job_id
+        job_type = notification.job_type
+
+        with tracer.start_as_current_span("sessions_bus.process_job") as span:
+            span.set_attribute("job_id", str(job_id))
+            span.set_attribute("session_id", str(session_id))
+            span.set_attribute("job_type", job_type)
+
+            event = self._convert_to_cloud_event(notification)
+
+            try:
+                session_key = await self._require_key_provider().get_session_key(session_id)
+                context = self._build_context(session_id, job_id, session_key)
+                result = await self._dispatch_cloud_event(event, context)
+
+                if result.status.value == "no_handler_found":
+                    logger.warning("No handler found for job type %s (job_id=%s)", job_type, job_id)
+
+            except InvalidEventError as e:
+                await self._cancel_invalid_job(session_id, job_id, e)
+
+            except RetryableHandlerError as e:
+                logger.warning("Retryable error for job %s: %s. Job remains pending.", job_id, e)
+
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code != 403:
+                    raise
+                await self._retry_with_fresh_key(event, session_id, job_id)
+
+            except Exception as e:
+                logger.exception("Unexpected error processing job %s: %s", job_id, e)
+
+    def _require_key_provider(self) -> SessionKeyProvider:
+        if self._key_provider is None:
+            raise RuntimeError("SessionKeyProvider not initialized")
+        return self._key_provider
+
+    def _require_api_client(self) -> SessionsApiClient:
+        if self._api_client is None:
+            raise RuntimeError("SessionsApiClient not initialized")
+        return self._api_client
+
+    def _build_context(self, session_id: UUID, job_id: UUID, session_key: str) -> dict[str, Any]:
+        return {
+            "session_id": str(session_id),
+            "job_id": str(job_id),
+            "session_key": session_key,
+            "sessions_api_client": self._api_client,
+            "sessions_key_provider": self._key_provider,
+        }
+
+    async def _cancel_invalid_job(self, session_id: UUID, job_id: UUID, error: InvalidEventError) -> None:
+        logger.error("Invalid job %s: %s. Cancelling.", job_id, error)
+        try:
+            session_key = await self._require_key_provider().get_session_key(session_id)
+            await self._require_api_client().cancel_job(
+                session_id=session_id,
+                job_id=job_id,
+                session_key=session_key,
+                reason=f"Invalid event: {error}",
+            )
+        except Exception as cancel_error:
+            logger.error("Failed to cancel job %s: %s", job_id, cancel_error)
+
+    async def _retry_with_fresh_key(self, event: GenericCloudEvent, session_id: UUID, job_id: UUID) -> None:
+        # A 403 from a handler means the cached session key is stale. Invalidate and retry
+        # once through the SAME dispatch seam as the happy path (no separate code path).
+        logger.error("Invalid session key for session %s", session_id)
+        key_provider = self._require_key_provider()
+        key_provider.invalidate_cache(session_id)
+        try:
+            session_key = await key_provider.get_session_key(session_id)
+            context = self._build_context(session_id, job_id, session_key)
+            await self._dispatch_cloud_event(event, context)
+        except Exception as retry_error:
+            logger.error("Retry failed for job %s: %s", job_id, retry_error)
+            raise InvalidEventError(
+                status="invalid_session_key",
+                reason=f"Session key invalid: {retry_error}",
+            ) from retry_error
+```
+
+- [ ] **Step 7: Update `_convert_to_cloud_event` to take a `JobNotification`**
+
+Replace the whole method with:
+
+```python
+    def _convert_to_cloud_event(self, notification: JobNotification) -> GenericCloudEvent:
+        """Convert a job notification to CloudEvent format.
+
+        Args:
+            notification: Parsed job notification
+
+        Returns:
+            GenericCloudEvent with the full job payload as ``data``
+        """
+        event_type = f"sessions.job.created.{notification.job_type}"
+        kwargs: dict[str, Any] = {
+            "specversion": "1.0",
+            "id": str(notification.job_id),
+            "type": event_type,
+            "source": "/sessions-service",
+            "subject": str(notification.session_id),
+            "datacontenttype": "application/json",
+            "data": notification.payload(),
+        }
+        # Only set `time` when present — GenericCloudEvent rejects a None time; omitting it
+        # lets the model apply its default timestamp.
+        if notification.created_at is not None:
+            kwargs["time"] = notification.created_at
+        return GenericCloudEvent(**kwargs)
+```
+
+### Tests
+
+- [ ] **Step 8: Replace the `job_data` fixture usage with a `notification` fixture**
+
+In `test_sessions_bus.py`, add near the other fixtures:
+
+```python
+from blueprint.agents.models.sessions import JobNotification
+
+
+@pytest.fixture
+def notification() -> JobNotification:
+    return JobNotification(
+        session_id=uuid4(),
+        job_id=uuid4(),
+        job_type="transcription",
+        created_at="2024-01-01T00:00:00Z",
+    )
+```
+
+- [ ] **Step 9: Update the existing `TestConvertToCloudEvent` tests to pass a `JobNotification`**
+
+Replace the `TestConvertToCloudEvent` class body with:
+
+```python
+class TestConvertToCloudEvent:
+    def _n(self, **overrides) -> JobNotification:
+        base = {
+            "session_id": uuid4(),
+            "job_id": uuid4(),
+            "job_type": "transcription",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+        base.update(overrides)
+        return JobNotification(**base)
+
+    def test_event_type_includes_job_type(self, sessions_bus: SessionsBus) -> None:
+        event = sessions_bus._convert_to_cloud_event(self._n(job_type="analysis"))
+        assert event.type == "sessions.job.created.analysis"
+
+    def test_event_id_is_job_id(self, sessions_bus: SessionsBus) -> None:
+        job_id = uuid4()
+        event = sessions_bus._convert_to_cloud_event(self._n(job_id=job_id))
+        assert event.id == str(job_id)
+
+    def test_subject_is_session_id(self, sessions_bus: SessionsBus) -> None:
+        session_id = uuid4()
+        event = sessions_bus._convert_to_cloud_event(self._n(session_id=session_id))
+        assert event.subject == str(session_id)
+
+    def test_source_is_sessions_service(self, sessions_bus: SessionsBus) -> None:
+        event = sessions_bus._convert_to_cloud_event(self._n())
+        assert event.source == "/sessions-service"
+
+    def test_data_payload_contains_job_fields(self, sessions_bus: SessionsBus) -> None:
+        n = self._n(job_type="analysis")
+        event = sessions_bus._convert_to_cloud_event(n)
+        assert event.data["job_type"] == "analysis"
+        assert event.data["session_id"] == str(n.session_id)
+```
+
+- [ ] **Step 10: Update the existing `TestProcessJobNotification` tests to pass a `JobNotification`**
+
+Replace every `job_data: dict` parameter with `notification: JobNotification` (the new fixture) and every `_process_job_notification(job_data)` call with `_process_job_notification(notification)`. Update the two id-based assertions to use `notification.job_id`. Also update the 403 test so the retry uses the unified dispatch seam:
+
+```python
+    async def test_403_invalidates_cache_and_retries(
+        self, started_sessions_bus: SessionsBus, notification: JobNotification
+    ) -> None:
+        response_mock = MagicMock()
+        response_mock.status_code = 403
+        http_err = httpx.HTTPStatusError("403", request=MagicMock(), response=response_mock)
+        processed = ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
+        # First dispatch raises 403; the retry (same seam) succeeds.
+        started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=[http_err, processed])  # type: ignore[method-assign]
+
+        await started_sessions_bus._process_job_notification(notification)
+
+        started_sessions_bus._key_provider.invalidate_cache.assert_called_once()
+        assert started_sessions_bus._dispatch_cloud_event.await_count == 2
+```
+
+And the retry-failure test (retry now goes through `_dispatch_cloud_event`):
+
+```python
+    async def test_403_retry_failure_propagates_invalid_event_error(
+        self, started_sessions_bus: SessionsBus, notification: JobNotification
+    ) -> None:
+        response_mock = MagicMock()
+        response_mock.status_code = 403
+        http_err = httpx.HTTPStatusError("403", request=MagicMock(), response=response_mock)
+        started_sessions_bus._dispatch_cloud_event = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[http_err, RuntimeError("still broken")]
+        )
+        with pytest.raises(InvalidEventError, match="Session key invalid"):
+            await started_sessions_bus._process_job_notification(notification)
+```
+
+For `test_invalid_event_error_cancels_job`, update the assertion to `notification.job_id`:
+
+```python
+        assert call_kwargs["job_id"] == notification.job_id
+```
+
+- [ ] **Step 11: Add `_dispatch_sse_event` tests (keepalive #44, parsing, unknown)**
+
+Append a new class:
+
+```python
+from types import SimpleNamespace
+
+
+class TestDispatchSseEvent:
+    def test_keepalive_message_frame_is_debug_not_warning(
+        self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sse = SimpleNamespace(event="message", data="")
+        with caplog.at_level("DEBUG"):
+            sessions_bus._dispatch_sse_event(sse)
+        assert "keepalive" in caplog.text.lower()
+        assert "Unknown SSE event type" not in caplog.text
+
+    def test_named_unknown_event_with_payload_warns(
+        self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sse = SimpleNamespace(event="surprise", data="{}")
+        with caplog.at_level("WARNING"):
+            sessions_bus._dispatch_sse_event(sse)
+        assert "Unknown SSE event type: surprise" in caplog.text
+
+    def test_job_created_creates_tracked_task(self, started_sessions_bus: SessionsBus) -> None:
+        started_sessions_bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
+        payload = '{"session_id": "00000000-0000-0000-0000-000000000001", ' \
+                  '"job_id": "00000000-0000-0000-0000-000000000002", "job_type": "t"}'
+        sse = SimpleNamespace(event="job_created", data=payload)
+        started_sessions_bus._dispatch_sse_event(sse)
+        assert len(started_sessions_bus._inflight_tasks) == 1
+
+    def test_malformed_job_payload_is_logged_and_skipped(
+        self, started_sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sse = SimpleNamespace(event="job_created", data='{"missing": "ids"}')
+        with caplog.at_level("ERROR"):
+            started_sessions_bus._dispatch_sse_event(sse)
+        assert "Error processing SSE event" in caplog.text
+        assert len(started_sessions_bus._inflight_tasks) == 0
+```
+
+- [ ] **Step 12: Run the full bus test file**
+
+Run: `uv run pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py -v`
+Expected: PASS. If `test_job_created_creates_tracked_task` warns about a pending task at teardown, that is acceptable (the AsyncMock coroutine is scheduled); the assertion runs synchronously before the loop yields.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/blueprint/agents/io/api/eventing/sessions_bus.py tests/unit/agents/io/api/eventing/test_sessions_bus.py
+git commit -m "refactor(sessions): model job notifications, split dispatch, ignore keepalive frames (#44)"
+```
+
+---
+
+## Task 7: SessionsBus — drain in-flight jobs and unregister on shutdown (Refactor #5 + #45 shutdown)
+
+**Files:**
+- Modify: `src/blueprint/agents/io/api/eventing/sessions_bus.py` (`on_shutdown` + new `_drain_inflight_jobs`)
+- Test: `tests/unit/agents/io/api/eventing/test_sessions_bus.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new class:
+
+```python
+class TestShutdownDrainAndUnregister:
+    async def test_unregisters_after_draining(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._agent_id = "agent-001"
+        bus._api_client.unregister_agent = AsyncMock()
+
+        async def _job() -> None:
+            await asyncio.sleep(0.01)
+
+        task = asyncio.create_task(_job())
+        bus._inflight_tasks.add(task)
+        task.add_done_callback(bus._inflight_tasks.discard)
+
+        await bus.on_shutdown()
+
+        assert task.done()
+        bus._api_client.unregister_agent.assert_awaited_once_with("agent-001")
+
+    async def test_drain_timeout_cancels_and_still_unregisters(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._agent_id = "agent-001"
+        bus._job_timeout = 0  # force immediate drain timeout
+        bus._api_client.unregister_agent = AsyncMock()
+
+        async def _slow_job() -> None:
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(_slow_job())
+        bus._inflight_tasks.add(task)
+        task.add_done_callback(bus._inflight_tasks.discard)
+
+        await bus.on_shutdown()
+
+        assert task.cancelled()
+        bus._api_client.unregister_agent.assert_awaited_once()
+
+    async def test_unregister_failure_does_not_raise(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._agent_id = "agent-001"
+        bus._api_client.unregister_agent = AsyncMock(side_effect=RuntimeError("boom"))
+        # unregister_agent swallows internally, but guard shutdown even if it did not.
+        await bus.on_shutdown()
+```
+
+> Note: `test_unregister_failure_does_not_raise` documents that shutdown is robust; `unregister_agent` already swallows its own errors (Task 3), so this asserts no exception escapes `on_shutdown`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py::TestShutdownDrainAndUnregister -v`
+Expected: FAIL — `on_shutdown` does not drain or call `unregister_agent`.
+
+- [ ] **Step 3: Rewrite `on_shutdown` and add `_drain_inflight_jobs`**
+
+Replace `on_shutdown` with:
+
+```python
+    async def on_shutdown(self) -> None:
+        """Stop the stream, drain in-flight jobs, then unregister."""
+        logger.info("SessionsBus closing...")
+
+        self._shutdown_event.set()
+
+        if self._sse_task and not self._sse_task.done():
+            self._sse_task.cancel()
+            try:
+                await self._sse_task
+            except asyncio.CancelledError:
+                logger.info("SSE task cancelled")
+
+        await self._drain_inflight_jobs()
+
+        if self._api_client is not None and self._agent_id:
+            await self._api_client.unregister_agent(self._agent_id)
+
+        logger.info("SessionsBus closed")
+
+    async def _drain_inflight_jobs(self) -> None:
+        """Wait for in-flight job tasks to finish (bounded by job_timeout), so we do
+        not unregister or exit while a job is still reporting results. Tasks still
+        running after the timeout are cancelled so shutdown cannot hang."""
+        if not self._inflight_tasks:
+            return
+        pending = list(self._inflight_tasks)
+        logger.info("Draining %d in-flight job(s) (timeout=%ds)", len(pending), self._job_timeout)
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=self._job_timeout,
+            )
+        except TimeoutError:
+            logger.warning("Drain timeout — cancelling %d in-flight job(s)", len(self._inflight_tasks))
+            for task in list(self._inflight_tasks):
+                task.cancel()
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py::TestShutdownDrainAndUnregister -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/blueprint/agents/io/api/eventing/sessions_bus.py tests/unit/agents/io/api/eventing/test_sessions_bus.py
+git commit -m "feat(sessions): drain in-flight jobs and unregister on shutdown (#45)"
+```
+
+---
+
+## Task 8: Docs — CHANGELOG + event-processing concept
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/concepts/event-processing.md`
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Under the v0.7.0 (Unreleased) section — match the file's existing heading style; if there is a `### Fixed` subsection use it, otherwise add one — add:
+
+```markdown
+### Fixed
+- `SessionsBus` now registers with the sessions dispatch registry (`POST /agents/register`) before
+  opening the SSE job stream and re-registers on every reconnect, fixing the 403 gate introduced by
+  sessions v0.4.0 that put all deployed agents into a reconnect loop (#45).
+- Keepalive comment frames on the SSE stream are no longer logged as `Unknown SSE event type: message` (#44).
+
+### Changed
+- `SessionsBus` unregisters (`DELETE /agents/{agent_id}`) and drains in-flight jobs on graceful shutdown.
+```
+
+- [ ] **Step 2: Add a note to the event-processing concept doc**
+
+In `docs/concepts/event-processing.md`, find the section describing the sessions SSE flow (search for `SessionsBus` or `stream/sse`) and add a short paragraph:
+
+```markdown
+> **Agent registration (sessions v0.4.0+):** Before opening the SSE job stream, `SessionsBus` calls
+> `POST /agents/register` to declare its `agent_id`, `agent_type`, and `capabilities` — the dispatch
+> source of truth. It re-registers before every reconnect attempt (idempotent) and unregisters
+> (`DELETE /agents/{agent_id}`) on graceful shutdown. Against a pre-v0.4.0 server the register call
+> returns 404 and is skipped.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md docs/concepts/event-processing.md
+git commit -m "docs(sessions): document agent registration flow (#45, #44)"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full unit + offline test suite**
+
+Run: `uv run pytest tests/ -m "not integration"`
+Expected: PASS, no failures. In particular `tests/integration/test_sessions_startup_resilience.py::test_app_starts_when_sessions_service_unreachable` (offline, not marked integration) must still pass — register failure happens inside the SSE task and must not block startup.
+
+- [ ] **Step 2: Run the quality gate**
+
+Run: `black src/ tests/ && ruff check src/ tests/ && mypy src/`
+Expected: all clean. Fix any findings in the touched files only.
+
+- [ ] **Step 3: Confirm the commit series is coherent**
+
+Run: `git log --oneline develop..HEAD`
+Expected: the docs/spec commits plus Tasks 1–8 as separate, well-scoped commits.
+
+- [ ] **Step 4 (optional): open the PR**
+
+Only if the user asks. Target `develop` (protected — PR only, human review required). Suggested title: `fix(sessions): register with dispatch registry before opening SSE stream (#45, #44)`. Reference the spec and both issues in the body.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** register-before-connect (Task 5/6), re-register per reconnect (Task 6 — call is inside `_connect_and_consume`, which the reconnect loop re-invokes), 404 legacy handling (Task 2), surface 403 body (Task 2 register + Task 6 SSE wrap), keepalive #44 (Task 6), unregister on shutdown (Task 7), `_request` helper #1 (Task 1), single dispatch seam #2 (Task 6 `_retry_with_fresh_key`), error-policy extraction #3 (Task 6), `JobNotification` #4 (Tasks 4, 6), shutdown drain #5 (Task 7), config unchanged (no task needed), docs (Task 8), integration resilience preserved (Task 9). All spec sections map to a task.
+- **Placeholder scan:** none — every code and test step contains complete code.
+- **Type consistency:** `register_agent(agent_id, agent_type, capabilities, version=None, metadata=None) -> bool` and `unregister_agent(agent_id) -> None` used identically in Tasks 2/3/5/6/7. `JobNotification(session_id, job_id, job_type, created_at)` + `.payload()` used consistently in Tasks 4/6. `_dispatch_cloud_event`, `_convert_to_cloud_event(notification)`, `_build_context`, `_require_key_provider`, `_require_api_client` names are consistent across steps.

--- a/docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md
+++ b/docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md
@@ -1,0 +1,220 @@
+# SessionsBus: register with the dispatch registry before opening the SSE stream
+
+- **Date:** 2026-07-06
+- **Issues:** [#45](https://github.com/bechtleav360/AVS.AI.Blueprint.AgenticService/issues/45) (register-before-connect), [#44](https://github.com/bechtleav360/AVS.AI.Blueprint.AgenticService/issues/44) (keepalive log noise) — both closed by this work
+- **Milestone:** v0.7.0
+
+## Problem
+
+Sessions service **v0.4.0** gates the SSE job stream on an explicit agent registry
+(`service-sessions` #27/#82). `GET /jobs/stream/sse` returns **403 (JSON)** unless the
+agent has previously called `POST /agents/register`. `SessionsBus` connects straight to
+the stream without registering, so after the v0.4.0 deploy all deployed agents fell into
+an infinite 5-second reconnect loop:
+
+```
+httpx_sse._exceptions.SSEError: Expected response header Content-Type to contain
+'text/event-stream', got 'application/json'
+Reconnecting in 5 seconds...
+```
+
+The `SSEError` hides the real status/reason, which cost most of the diagnosis time.
+
+A related papercut (#44): the service emits an SSE keepalive comment frame (`: keepalive`
+with an `id:` and no `event:`/`data:`) every 30 s. `SessionsBus` dispatches it as a
+default-type `message` event with empty data, which falls through to a
+`WARNING - Unknown SSE event type: message` on every tick — one per keepalive, indefinitely.
+
+## Server contract (verified against `service-sessions`)
+
+`POST {base_url}/agents/register` — no `/api` prefix internally (the manual stopgap's `/api`
+was the ingress path; relative to the configured `base_url` it is `/agents/register`, matching
+the existing `SessionsApiClient` endpoints such as `/sessions/{id}/jobs/...`).
+
+- **Auth:** service-wide `X-Api-Key` (same gate as `/jobs/*`). No session key.
+- **Request body** (`AgentRegisterRequest`): `agent_id` (str, required), `agent_type` (str, required),
+  `capabilities` (list[str], default `[]` = all job types — **this is the dispatch source of truth**,
+  not the SSE query string), `version` (str, optional), `metadata` (dict, optional).
+- **Response:** **201** on first (or post-expiry) registration; **200** when re-posting a still-live
+  `agent_id` (heartbeat refresh that re-declares capabilities). Both are success.
+- **Liveness:** registrations live in RAM and lapse after a heartbeat TTL (~60 s) unless refreshed by
+  a re-register or by SSE keepalives. An open stream does not expire.
+- **Graceful teardown:** `DELETE {base_url}/agents/{agent_id}` — idempotent, returns **204** whether or
+  not the agent was registered.
+- **Legacy servers** (< v0.4.0) have no `/agents/register` route → the call returns **404**.
+
+## Design decisions
+
+1. **Scope:** fix #45 and #44 together — both touch the SSE connect/consume path (`_connect_and_consume`).
+2. **Registration lives in `SessionsApiClient`**, alongside `start_job`/`complete_job`/`cancel_job`. It
+   already owns the persistent `httpx.AsyncClient` with the `X-Api-Key` header baked in, and is cleanly
+   unit-testable.
+3. **Register on the per-attempt path**, not in `on_startup`. Registering at the top of
+   `_connect_and_consume()` satisfies "re-register before every reconnect attempt" *and* covers the very
+   first connect (the SSE task's first iteration), so no separate `on_startup` register call is needed.
+4. **Registration failure == connection failure.** A hard register failure raises and flows into the
+   existing reconnect/backoff loop — no new control flow. This also preserves app-startup resilience:
+   failures occur inside the background SSE task, never in `on_startup`.
+5. **Graceful unregister on shutdown**, using the `DELETE` endpoint (best-effort).
+
+## Components
+
+### `SessionsApiClient.register_agent(...)` (new)
+
+```python
+async def register_agent(
+    self,
+    agent_id: str,
+    agent_type: str,
+    capabilities: list[str],
+    version: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Register the agent with the sessions dispatch registry (idempotent).
+
+    Returns True when the server accepted the registration (200/201).
+    Returns False when the server is a legacy (< v0.4.0) instance without the
+    endpoint (404) — the caller may still open the stream. Raises on any other
+    non-2xx so the reconnect loop backs off.
+    """
+```
+
+Behaviour:
+
+- `POST {base_url}/agents/register` with `{agent_id, agent_type, capabilities}` (+ `version`/`metadata`
+  only if provided). No per-call auth header — `X-Api-Key` is already a default header on `self._client`.
+- **200 / 201** → log at INFO (include status), return `True`.
+- **404** → log once at WARNING ("sessions service has no /agents/register; legacy < v0.4.0, proceeding
+  without registration"), return `False`.
+- **Any other non-2xx** → log status **and `response.text`** (satisfies "surface the 403 body"), then
+  `response.raise_for_status()`.
+- Guard for uninitialised client (mirror the other methods: `raise ValueError` if `self._client is None`).
+
+### `SessionsApiClient.unregister_agent(...)` (new)
+
+```python
+async def unregister_agent(self, agent_id: str) -> None:
+    """Best-effort graceful deregistration (idempotent DELETE). Never raises."""
+```
+
+- `DELETE {base_url}/agents/{agent_id}`.
+- Swallow **all** exceptions (network error, 404 on legacy, closed client) — log at WARNING on failure,
+  INFO on success. Shutdown must never fail because of this call.
+
+### `SessionsBus` changes
+
+**`_connect_and_consume()` — register before opening the stream:**
+
+```python
+async def _connect_and_consume(self) -> None:
+    # Register (or refresh) before opening the stream. On a legacy server this
+    # is a no-op (404 → False); on a hard failure it raises → reconnect backoff.
+    await self._api_client.register_agent(
+        agent_id=self._agent_id,
+        agent_type=self._agent_type,
+        capabilities=self._capabilities,
+    )
+
+    url = f"{self._base_url}/jobs/stream/sse"
+    ...  # existing connect logic unchanged below
+```
+
+**Keepalive handling (#44)** in the event-dispatch branch — a default-type `message` frame with empty
+data is a keepalive comment, not an event:
+
+```python
+elif sse.event == "heartbeat":
+    logger.debug("SSE heartbeat received")
+
+elif sse.event == "message" and not (sse.data or "").strip():
+    logger.debug("SSE keepalive frame received")   # #44 — was WARNING
+
+else:
+    logger.warning("Unknown SSE event type: %s", sse.event)
+```
+
+Named events *with* a payload still reach the `Unknown SSE event type` WARNING.
+
+**403 diagnostics** — wrap the event iteration so a rejected stream surfaces its real status and body
+instead of an opaque `SSEError`:
+
+```python
+async with aconnect_sse(client, "GET", url, params=params, headers=headers) as event_source:
+    logger.info("SSE connection established")
+    try:
+        async for sse in event_source.aiter_sse():
+            ...
+    except SSEError:
+        resp = event_source.response
+        body = (await resp.aread()).decode(errors="replace")[:500]
+        logger.error("SSE stream rejected: status=%d body=%s", resp.status_code, body)
+        raise   # let the reconnect loop back off
+```
+
+**`on_shutdown()` — unregister after cancelling the task:**
+
+```python
+async def on_shutdown(self) -> None:
+    self._shutdown_event.set()
+    # cancel the SSE task (existing logic) ...
+    if self._api_client and self._agent_id:
+        await self._api_client.unregister_agent(self._agent_id)
+```
+
+Teardown order makes the client available here: `SessionsBus` is registered as a *lifecycle component*
+(torn down first, `app_builder.py` line ~348), whereas `SessionsApiClient` is a *service* (torn down
+later, line ~392). The client's `httpx.AsyncClient` is therefore still open when `on_shutdown` runs.
+
+## Error-handling semantics
+
+| Event | Outcome |
+|---|---|
+| register 200 / 201 | proceed to open stream |
+| register 404 | log "legacy server", proceed to open stream |
+| register 4xx / 5xx / network error | log status + body, raise → reconnect backoff, retry next cycle |
+| stream opens then drops | existing backoff → next cycle re-registers |
+| SSE stream rejected (non-`text/event-stream`) | log real status + body, raise → backoff |
+| keepalive `message` frame, empty data | DEBUG log, ignored (#44) |
+| shutdown | cancel SSE task → best-effort `DELETE` unregister |
+
+## Configuration
+
+No new required config. `base_url`, `agent_id`, `agent_type`, `capabilities`, `api_key` are all already
+loaded by `SessionsBus.on_startup`. `version`/`metadata` are intentionally **not** plumbed through
+(YAGNI) — they can be added later without changing the method signatures (both are optional kwargs).
+
+## Testing
+
+**Unit — `SessionsApiClient`** (extend `tests/unit/agents/services/sessions/test_api_client.py`):
+- `register_agent` 201 → returns `True`, POSTs to `/agents/register` with the expected body.
+- `register_agent` 200 → returns `True` (heartbeat refresh).
+- `register_agent` 404 → returns `False`, does **not** raise, logs the legacy warning.
+- `register_agent` 500 → raises `HTTPStatusError`, response body appears in the log.
+- `register_agent` uninitialised client → `ValueError`.
+- `unregister_agent` 204 → no raise; network error → swallowed (no raise), logged at WARNING.
+
+**Unit — `SessionsBus`** (`tests/unit/agents/io/api/eventing/test_sessions_bus.py`):
+- `_connect_and_consume` calls `register_agent` **before** `aconnect_sse` (patch both; assert order).
+- `register_agent` raising propagates out of `_connect_and_consume` (so `_consume_sse_stream` backs off).
+- `on_shutdown` calls `unregister_agent(agent_id)` once, after task cancellation, and does not raise if it fails.
+- A `message` SSE frame with empty data logs at DEBUG and is **not** counted as an unknown event (#44).
+- A named unknown event with a payload still logs the WARNING.
+
+**Integration** (`tests/integration/test_sessions_startup_resilience.py`):
+- Existing `test_app_starts_when_sessions_service_unreachable` must still pass unchanged — a register
+  failure happens inside the background SSE task and must not block `on_startup`/lifespan completion.
+
+## Docs
+
+- `CHANGELOG.md`: entry under **v0.7.0** — "SessionsBus now registers with the sessions dispatch registry
+  before opening the SSE stream (fixes 403 gate on sessions v0.4.0); keepalive frames no longer logged as
+  unknown events. Closes #45, #44."
+- `docs/concepts/event-processing.md`: add a note that SessionsBus registers (and re-registers on every
+  reconnect) before streaming, and unregisters on graceful shutdown.
+
+## Out of scope
+
+- Feeding registration status into `SessionsServiceHealthChecker` (health already tracks REST reachability
+  + SSE heartbeat; registration failures surface via the reconnect-loop logs).
+- Any change to the SSE query-string params (`agent_type`/`capabilities`) — accepted but ignored by
+  v0.4.0; left as-is for backward compatibility with older servers.

--- a/docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md
+++ b/docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md
@@ -235,8 +235,9 @@ small, self-contained diff.
    `job_data.get("job_id")` is silently `None`). Add a small pydantic `JobNotification` (fields:
    `session_id: UUID`, `job_id: UUID`, `job_type: str`, `created_at`, `data`) parsed **once** in
    `_connect_and_consume`'s `job_created` branch; pass the typed object to `_handle_job_notification` /
-   `_process_job_notification` / `_convert_to_cloud_event`. A malformed notification becomes an
-   `InvalidEventError` at the boundary instead of a `KeyError` deep in processing.
+   `_process_job_notification` / `_convert_to_cloud_event`. A malformed payload is caught and logged at
+   the boundary (the stream keeps consuming) instead of raising a `KeyError` deep in processing — it
+   cannot be cancelled because a malformed notification has no reliable job/session id.
 
 5. **Shutdown drain for in-flight job tasks** — *robustness note from the review.* Jobs are launched
    fire-and-forget via `asyncio.create_task(...)` (`sessions_bus.py:187`) and today are orphaned on
@@ -258,7 +259,7 @@ the fix.
 | register 4xx / 5xx / network error | log status + body, raise → reconnect backoff, retry next cycle |
 | stream opens then drops | existing backoff → next cycle re-registers |
 | SSE stream rejected (non-`text/event-stream`) | log real status + body, raise → backoff |
-| malformed `job_created` payload | `InvalidEventError` at the SSE boundary → job cancelled, stream continues |
+| malformed `job_created` payload | logged at ERROR at the SSE boundary, event skipped, stream continues |
 | keepalive `message` frame, empty data | DEBUG log, ignored (#44) |
 | shutdown | stop stream → drain in-flight jobs (bounded) → best-effort `DELETE` unregister |
 
@@ -288,8 +289,8 @@ loaded by `SessionsBus.on_startup`. `version`/`metadata` are intentionally **not
 - A named unknown event with a payload still logs the WARNING.
 - **Refactor #2:** the 403-retry path invokes `_dispatch_cloud_event` (not `EventProcessingService.process_event`
   directly) — update `test_403_invalidates_cache_and_retries` accordingly.
-- **Refactor #4:** a malformed `job_created` payload raises `InvalidEventError` at the boundary and the
-  stream keeps consuming (one bad job does not drop the connection).
+- **Refactor #4:** a malformed `job_created` payload is logged and skipped at the boundary and the
+  stream keeps consuming (one bad frame does not drop the connection or create a job task).
 - **Refactor #5:** `on_shutdown` awaits an in-flight job task before unregistering; a job exceeding the
   drain timeout does not hang shutdown.
 

--- a/docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md
+++ b/docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md
@@ -56,8 +56,42 @@ the existing `SessionsApiClient` endpoints such as `/sessions/{id}/jobs/...`).
    existing reconnect/backoff loop — no new control flow. This also preserves app-startup resilience:
    failures occur inside the background SSE task, never in `on_startup`.
 5. **Graceful unregister on shutdown**, using the `DELETE` endpoint (best-effort).
+6. **Fold in Brooks-Lint review findings.** A PR-review of the two touched files (2026-07-06, health
+   84/100) surfaced pre-existing conditions worth fixing while we are in this code: a shared request
+   helper in `SessionsApiClient`, a single dispatch seam in `SessionsBus`, extraction of the four error
+   policies out of `_process_job_notification`, a typed `JobNotification` model, and a defined shutdown
+   drain for in-flight job tasks. Detail in [Folded-in refactors](#folded-in-refactors-brooks-lint-review).
+   These are separate commits within the PR so the registration change stays reviewable on its own.
 
 ## Components
+
+### `SessionsApiClient._request(...)` (new, shared — folds in Suggestion #4)
+
+Every existing method repeats the same preamble: the `if not self._client: raise ValueError("...not
+initialized...")` guard, URL assembly, header assembly, `raise_for_status()`, `.json()`, and a log line.
+Adding `register_agent`/`unregister_agent` would copy it a fifth and sixth time. Extract it once:
+
+```python
+async def _request(
+    self,
+    method: str,
+    path: str,
+    *,
+    session_key: str | None = None,
+    json: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Issue an authenticated request to the sessions service.
+
+    Owns the client-initialised guard, URL assembly, and the optional X-Session-Key
+    header. Returns the raw Response so callers decide how to treat status codes
+    (register/unregister need to branch on 404 rather than always raise_for_status).
+    """
+```
+
+- The four existing methods (`start_job`, `get_job_detail`, `complete_job`, `cancel_job`) migrate to
+  `_request(...)` + `raise_for_status()` + `.json()`, preserving their current behaviour exactly.
+- `_request` does **not** call `raise_for_status()` itself — registration needs to inspect 404/2xx
+  before deciding — so status handling stays with each caller.
 
 ### `SessionsApiClient.register_agent(...)` (new)
 
@@ -81,14 +115,14 @@ async def register_agent(
 
 Behaviour:
 
-- `POST {base_url}/agents/register` with `{agent_id, agent_type, capabilities}` (+ `version`/`metadata`
-  only if provided). No per-call auth header — `X-Api-Key` is already a default header on `self._client`.
+- `await self._request("POST", "/agents/register", json=payload)` with `payload = {agent_id, agent_type,
+  capabilities}` (+ `version`/`metadata` only if provided). `X-Api-Key` is already a default header on the
+  client; the guard lives in `_request`.
 - **200 / 201** → log at INFO (include status), return `True`.
 - **404** → log once at WARNING ("sessions service has no /agents/register; legacy < v0.4.0, proceeding
   without registration"), return `False`.
 - **Any other non-2xx** → log status **and `response.text`** (satisfies "surface the 403 body"), then
   `response.raise_for_status()`.
-- Guard for uninitialised client (mirror the other methods: `raise ValueError` if `self._client is None`).
 
 ### `SessionsApiClient.unregister_agent(...)` (new)
 
@@ -97,7 +131,7 @@ async def unregister_agent(self, agent_id: str) -> None:
     """Best-effort graceful deregistration (idempotent DELETE). Never raises."""
 ```
 
-- `DELETE {base_url}/agents/{agent_id}`.
+- `await self._request("DELETE", f"/agents/{agent_id}")`.
 - Swallow **all** exceptions (network error, 404 on legacy, closed client) — log at WARNING on failure,
   INFO on success. Shutdown must never fail because of this call.
 
@@ -133,7 +167,9 @@ else:
     logger.warning("Unknown SSE event type: %s", sse.event)
 ```
 
-Named events *with* a payload still reach the `Unknown SSE event type` WARNING.
+Named events *with* a payload still reach the `Unknown SSE event type` WARNING. The `job_created`
+branch parses `sse.data` into a `JobNotification` (see [Folded-in refactors](#folded-in-refactors-brooks-lint-review))
+rather than a raw dict.
 
 **403 diagnostics** — wrap the event iteration so a rejected stream surfaces its real status and body
 instead of an opaque `SSEError`:
@@ -151,19 +187,67 @@ async with aconnect_sse(client, "GET", url, params=params, headers=headers) as e
         raise   # let the reconnect loop back off
 ```
 
-**`on_shutdown()` — unregister after cancelling the task:**
+**`on_shutdown()` — stop the stream, drain in-flight jobs, then unregister:**
 
 ```python
 async def on_shutdown(self) -> None:
     self._shutdown_event.set()
     # cancel the SSE task (existing logic) ...
+    await self._drain_inflight_jobs()          # folds in the shutdown-drain refactor
     if self._api_client and self._agent_id:
         await self._api_client.unregister_agent(self._agent_id)
 ```
 
+The order is deliberate: setting `_shutdown_event` stops the consumer from accepting new jobs, we let
+in-flight job tasks finish (bounded by a drain timeout), and only then unregister — so we never pull the
+registration out from under a job that is still reporting results. See
+[Folded-in refactors](#folded-in-refactors-brooks-lint-review) for the task-tracking detail.
+
 Teardown order makes the client available here: `SessionsBus` is registered as a *lifecycle component*
 (torn down first, `app_builder.py` line ~348), whereas `SessionsApiClient` is a *service* (torn down
 later, line ~392). The client's `httpx.AsyncClient` is therefore still open when `on_shutdown` runs.
+
+## Folded-in refactors (Brooks-Lint review)
+
+From the 2026-07-06 PR review of the two touched files (health 84/100). Each is a **separate commit**
+within the PR, sequenced before the registration change where it de-risks it, so the core fix stays a
+small, self-contained diff.
+
+1. **`SessionsApiClient._request(...)` shared helper** — *Suggestion #4, Knowledge Duplication.* Extract
+   the client guard + URL/header assembly repeated across the four existing methods; the four migrate to
+   it with no behaviour change, and `register_agent`/`unregister_agent` build on it instead of copying the
+   preamble a fifth and sixth time. Do this **first** so the new methods land clean.
+
+2. **Single dispatch seam in `_process_job_notification`** — *Warning, Knowledge Duplication.* The happy
+   path dispatches via `self._dispatch_cloud_event(event, context)` (`sessions_bus.py:255`); the 403-retry
+   path bypasses the mixin and calls `EventProcessingService.process_event` directly (`:298-299`),
+   silently dropping the mixin's result/`no_handler_found` handling. Route the retry through
+   `_dispatch_cloud_event` too, so there is one dispatch path.
+
+3. **Extract the four error policies** — *Warning, Cognitive Overload.* `_process_job_notification`
+   (`:219-310`, ~80 lines) carries four recovery branches; the 403 branch raises inside an `except`, a
+   control-flow quirk the tests document with multi-paragraph docstrings (`test_sessions_bus.py:260-299`).
+   Extract `_cancel_invalid_job`, `_retry_with_fresh_key`, etc.; leave `_process_job_notification` a thin
+   dispatcher. Combine with refactor #2 (same branch).
+
+4. **`JobNotification` value object** — *Warning, Primitive Obsession / Domain Model Distortion.* The
+   notification is threaded as `dict[str, Any]` and read inconsistently (`job_data["session_id"]` raises;
+   `job_data.get("job_id")` is silently `None`). Add a small pydantic `JobNotification` (fields:
+   `session_id: UUID`, `job_id: UUID`, `job_type: str`, `created_at`, `data`) parsed **once** in
+   `_connect_and_consume`'s `job_created` branch; pass the typed object to `_handle_job_notification` /
+   `_process_job_notification` / `_convert_to_cloud_event`. A malformed notification becomes an
+   `InvalidEventError` at the boundary instead of a `KeyError` deep in processing.
+
+5. **Shutdown drain for in-flight job tasks** — *robustness note from the review.* Jobs are launched
+   fire-and-forget via `asyncio.create_task(...)` (`sessions_bus.py:187`) and today are orphaned on
+   shutdown. Track them in a set (add on create, discard on done via callback); `on_shutdown` awaits them
+   with a bounded timeout **before** unregistering (see the `on_shutdown` sketch above). The drain timeout
+   reuses the existing `job_timeout_seconds` config (already loaded) rather than adding a new knob; tasks
+   still running after it are cancelled so shutdown cannot hang.
+
+**Guard:** if refactors #2–#5 make the diff hard to review as one PR, split #4 (JobNotification) into a
+follow-up — it is the largest and is independent of the registration gate. #1–#3 and #5 should ship with
+the fix.
 
 ## Error-handling semantics
 
@@ -174,8 +258,9 @@ later, line ~392). The client's `httpx.AsyncClient` is therefore still open when
 | register 4xx / 5xx / network error | log status + body, raise → reconnect backoff, retry next cycle |
 | stream opens then drops | existing backoff → next cycle re-registers |
 | SSE stream rejected (non-`text/event-stream`) | log real status + body, raise → backoff |
+| malformed `job_created` payload | `InvalidEventError` at the SSE boundary → job cancelled, stream continues |
 | keepalive `message` frame, empty data | DEBUG log, ignored (#44) |
-| shutdown | cancel SSE task → best-effort `DELETE` unregister |
+| shutdown | stop stream → drain in-flight jobs (bounded) → best-effort `DELETE` unregister |
 
 ## Configuration
 
@@ -190,15 +275,23 @@ loaded by `SessionsBus.on_startup`. `version`/`metadata` are intentionally **not
 - `register_agent` 200 → returns `True` (heartbeat refresh).
 - `register_agent` 404 → returns `False`, does **not** raise, logs the legacy warning.
 - `register_agent` 500 → raises `HTTPStatusError`, response body appears in the log.
-- `register_agent` uninitialised client → `ValueError`.
+- `register_agent` uninitialised client → `ValueError` (guard now lives in `_request`).
 - `unregister_agent` 204 → no raise; network error → swallowed (no raise), logged at WARNING.
+- **Refactor #1:** existing `start_job`/`get_job_detail`/`complete_job`/`cancel_job` tests must stay green
+  unchanged after the migration to `_request` (behaviour-preserving — this is the regression guard).
 
 **Unit — `SessionsBus`** (`tests/unit/agents/io/api/eventing/test_sessions_bus.py`):
 - `_connect_and_consume` calls `register_agent` **before** `aconnect_sse` (patch both; assert order).
 - `register_agent` raising propagates out of `_connect_and_consume` (so `_consume_sse_stream` backs off).
-- `on_shutdown` calls `unregister_agent(agent_id)` once, after task cancellation, and does not raise if it fails.
+- `on_shutdown` calls `unregister_agent(agent_id)` once, after task cancellation + drain, and does not raise if it fails.
 - A `message` SSE frame with empty data logs at DEBUG and is **not** counted as an unknown event (#44).
 - A named unknown event with a payload still logs the WARNING.
+- **Refactor #2:** the 403-retry path invokes `_dispatch_cloud_event` (not `EventProcessingService.process_event`
+  directly) — update `test_403_invalidates_cache_and_retries` accordingly.
+- **Refactor #4:** a malformed `job_created` payload raises `InvalidEventError` at the boundary and the
+  stream keeps consuming (one bad job does not drop the connection).
+- **Refactor #5:** `on_shutdown` awaits an in-flight job task before unregistering; a job exceeding the
+  drain timeout does not hang shutdown.
 
 **Integration** (`tests/integration/test_sessions_startup_resilience.py`):
 - Existing `test_app_starts_when_sessions_service_unreachable` must still pass unchanged — a register

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -163,7 +163,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             raise RuntimeError("SessionsBus not started: agent_id is not set")
         await self._require_api_client().register_agent(
             agent_id=self._agent_id,
-            agent_type=self._agent_type or "",
+            agent_type=self._agent_type,
             capabilities=self._capabilities,
         )
 
@@ -277,7 +277,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             except httpx.HTTPStatusError as e:
                 if e.response.status_code != 403:
                     raise
-                await self._retry_with_fresh_key(event, session_id, job_id)
+                await self._retry_with_fresh_key(event, session_id, job_id, e)
 
             except Exception as e:
                 logger.exception("Unexpected error processing job %s: %s", job_id, e)
@@ -297,8 +297,8 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             "session_id": str(session_id),
             "job_id": str(job_id),
             "session_key": session_key,
-            "sessions_api_client": self._api_client,
-            "sessions_key_provider": self._key_provider,
+            "sessions_api_client": self._require_api_client(),
+            "sessions_key_provider": self._require_key_provider(),
         }
 
     async def _cancel_invalid_job(self, session_id: UUID, job_id: UUID, error: InvalidEventError) -> None:
@@ -314,7 +314,13 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         except Exception as cancel_error:
             logger.error("Failed to cancel job %s: %s", job_id, cancel_error)
 
-    async def _retry_with_fresh_key(self, event: GenericCloudEvent, session_id: UUID, job_id: UUID) -> None:
+    async def _retry_with_fresh_key(
+        self,
+        event: GenericCloudEvent,
+        session_id: UUID,
+        job_id: UUID,
+        original_error: httpx.HTTPStatusError,
+    ) -> None:
         # A 403 from a handler means the cached session key is stale. Invalidate and retry
         # once through the SAME dispatch seam as the happy path (no separate code path).
         logger.error("Invalid session key for session %s", session_id)
@@ -326,9 +332,11 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             await self._dispatch_cloud_event(event, context)
         except Exception as retry_error:
             logger.error("Retry failed for job %s: %s", job_id, retry_error)
+            # Report the original 403 in the reason (that is what the operator needs to see);
+            # chain from retry_error so the proximate failure is preserved in the traceback.
             raise InvalidEventError(
                 status="invalid_session_key",
-                reason=f"Session key invalid: {retry_error}",
+                reason=f"Session key invalid: {original_error}",
             ) from retry_error
 
     def _convert_to_cloud_event(self, notification: JobNotification) -> GenericCloudEvent:

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -6,19 +6,18 @@ for processing via the CloudEventProcessorMixin dispatch pipeline.
 """
 
 import asyncio
-import json
 import logging
 from typing import Any
 from uuid import UUID
 
 import httpx
-from httpx_sse import aconnect_sse
+from httpx_sse import ServerSentEvent, SSEError, aconnect_sse
 from opentelemetry import trace
 
 from ....component.component import Component
 from ....models.errors import InvalidEventError, RetryableHandlerError
 from ....models.events import GenericCloudEvent
-from ....services.eventing.event_processing_service import EventProcessingService
+from ....models.sessions import JobNotification
 from ....services.sessions import SessionKeyProvider, SessionsApiClient
 from .cloud_event_processor_mixin import CloudEventProcessorMixin
 
@@ -44,6 +43,9 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         # SSE connection
         self._sse_task: asyncio.Task[None] | None = None
         self._shutdown_event: asyncio.Event = asyncio.Event()
+
+        # In-flight job tasks (tracked so shutdown can drain them, not orphan them)
+        self._inflight_tasks: set[asyncio.Task[None]] = set()
 
         # Services (resolved on startup)
         self._api_client: SessionsApiClient | None = None
@@ -153,7 +155,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
                     pass
 
     async def _connect_and_consume(self) -> None:
-        """Establish SSE connection and consume events."""
+        """Register, then establish the SSE connection and consume events."""
         # v0.4.0 gates the stream on registration — register (idempotent) before every
         # connect attempt. On a legacy server this is a no-op (404 -> False); on a hard
         # failure it raises and the reconnect loop (in _consume_sse_stream) backs off.
@@ -165,10 +167,8 @@ class SessionsBus(Component, CloudEventProcessorMixin):
 
         url = f"{self._base_url}/jobs/stream/sse"
         params: dict[str, Any] = {"agent_id": self._agent_id}
-
         if self._agent_type:
             params["agent_type"] = self._agent_type
-
         if self._capabilities:
             params["capabilities"] = ",".join(self._capabilities)
 
@@ -177,166 +177,179 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         async with httpx.AsyncClient(timeout=None) as client:
             async with aconnect_sse(client, "GET", url, params=params, headers=headers) as event_source:
                 logger.info("SSE connection established")
+                try:
+                    async for sse in event_source.aiter_sse():
+                        if self._shutdown_event.is_set():
+                            break
+                        self._dispatch_sse_event(sse)
+                except SSEError:
+                    # aconnect_sse hides the real status when the server returns JSON (e.g. a
+                    # 403 dispatch-gate rejection). Surface status + body before backing off.
+                    resp = event_source.response
+                    body = (await resp.aread()).decode(errors="replace")[:500]
+                    logger.error("SSE stream rejected: status=%d body=%s", resp.status_code, body)
+                    raise
 
-                async for sse in event_source.aiter_sse():
-                    if self._shutdown_event.is_set():
-                        break
+    def _dispatch_sse_event(self, sse: ServerSentEvent) -> None:
+        """Route a single SSE frame. Keepalive comment frames are ignored (#44)."""
+        try:
+            if sse.event == "connected":
+                logger.info("SSE connected event received")
 
-                    try:
-                        if sse.event == "connected":
-                            logger.info("SSE connected event received")
+            elif sse.event == "job_created":
+                notification = JobNotification.model_validate_json(sse.data)
+                logger.info(
+                    "Job notification received: job_id=%s, job_type=%s",
+                    notification.job_id,
+                    notification.job_type,
+                )
+                task = asyncio.create_task(self._handle_job_notification(notification))
+                self._inflight_tasks.add(task)
+                task.add_done_callback(self._inflight_tasks.discard)
 
-                        elif sse.event == "job_created":
-                            job_data = json.loads(sse.data)
-                            logger.info(
-                                "Job notification received: job_id=%s, job_type=%s",
-                                job_data.get("job_id"),
-                                job_data.get("job_type"),
-                            )
-                            asyncio.create_task(self._handle_job_notification(job_data))
+            elif sse.event == "heartbeat":
+                logger.debug("SSE heartbeat received")
 
-                        elif sse.event == "heartbeat":
-                            logger.debug("SSE heartbeat received")
+            elif sse.event == "message" and not (sse.data or "").strip():
+                # Server keepalive comment frame (`: keepalive`) surfaces as a default-type
+                # `message` with empty data. Ignore it (#44) instead of warning every tick.
+                logger.debug("SSE keepalive frame received")
 
-                        else:
-                            logger.warning("Unknown SSE event type: %s", sse.event)
+            else:
+                logger.warning("Unknown SSE event type: %s", sse.event)
 
-                    except Exception as e:
-                        logger.error("Error processing SSE event: %s", e, exc_info=True)
+        except Exception as e:
+            logger.error("Error processing SSE event: %s", e, exc_info=True)
 
-    async def _handle_job_notification(self, job_data: dict[str, Any]) -> None:
+    async def _handle_job_notification(self, notification: JobNotification) -> None:
         """Handle job notification with concurrency control.
 
         Args:
-            job_data: Job notification data from SSE
+            notification: Parsed job notification from the SSE stream
         """
         if self._semaphore is None:
             raise RuntimeError("Semaphore not initialized")
         async with self._semaphore:
             try:
                 await asyncio.wait_for(
-                    self._process_job_notification(job_data),
+                    self._process_job_notification(notification),
                     timeout=self._job_timeout,
                 )
             except TimeoutError:
                 logger.error(
                     "Job processing timeout after %ds: job_id=%s",
                     self._job_timeout,
-                    job_data.get("job_id"),
+                    notification.job_id,
                 )
 
-    async def _process_job_notification(self, job_data: dict[str, Any]) -> None:
-        """Process a job notification by converting to CloudEvent and delegating to handlers.
-
-        Uses the CloudEventProcessorMixin dispatch pipeline for the primary call.
-        Applies sessions-specific error handling: permanent failures cancel the job,
-        transient failures leave it pending, 403 auth errors invalidate the session key
-        and retry once.
-
-        Args:
-            job_data: Job notification data from SSE
+    async def _process_job_notification(self, notification: JobNotification) -> None:
+        """Convert the notification to a CloudEvent and dispatch it, applying
+        sessions-specific error handling. Each recovery policy lives in its own
+        helper so this method stays a thin dispatcher.
         """
-        session_id = UUID(job_data["session_id"])
-        job_id = UUID(job_data["job_id"])
-        job_type = job_data["job_type"]
+        session_id = notification.session_id
+        job_id = notification.job_id
+        job_type = notification.job_type
 
         with tracer.start_as_current_span("sessions_bus.process_job") as span:
             span.set_attribute("job_id", str(job_id))
             span.set_attribute("session_id", str(session_id))
             span.set_attribute("job_type", job_type)
 
+            event = self._convert_to_cloud_event(notification)
+
             try:
-                # Get session key from provider
-                if self._key_provider is None:
-                    raise RuntimeError("SessionKeyProvider not initialized")
-                session_key = await self._key_provider.get_session_key(session_id)
-
-                event = self._convert_to_cloud_event(job_data)
-
-                context = {
-                    "session_id": str(session_id),
-                    "job_id": str(job_id),
-                    "session_key": session_key,
-                    "sessions_api_client": self._api_client,
-                    "sessions_key_provider": self._key_provider,
-                }
-
+                session_key = await self._require_key_provider().get_session_key(session_id)
+                context = self._build_context(session_id, job_id, session_key)
                 result = await self._dispatch_cloud_event(event, context)
 
                 if result.status.value == "no_handler_found":
-                    logger.warning(
-                        "No handler found for job type %s (job_id=%s)",
-                        job_type,
-                        job_id,
-                    )
+                    logger.warning("No handler found for job type %s (job_id=%s)", job_type, job_id)
 
             except InvalidEventError as e:
-                logger.error("Invalid job %s: %s. Cancelling.", job_id, e)
-                try:
-                    if self._key_provider is None:
-                        raise RuntimeError("SessionKeyProvider not initialized")
-                    if self._api_client is None:
-                        raise RuntimeError("SessionsApiClient not initialized")
-                    session_key = await self._key_provider.get_session_key(session_id)
-                    await self._api_client.cancel_job(
-                        session_id=session_id,
-                        job_id=job_id,
-                        session_key=session_key,
-                        reason=f"Invalid event: {str(e)}",
-                    )
-                except Exception as cancel_error:
-                    logger.error("Failed to cancel job %s: %s", job_id, cancel_error)
+                await self._cancel_invalid_job(session_id, job_id, e)
 
             except RetryableHandlerError as e:
-                logger.warning(
-                    "Retryable error for job %s: %s. Job remains pending.",
-                    job_id,
-                    e,
-                )
+                logger.warning("Retryable error for job %s: %s. Job remains pending.", job_id, e)
 
             except httpx.HTTPStatusError as e:
-                if e.response.status_code == 403:
-                    logger.error("Invalid session key for session %s", session_id)
-                    if self._key_provider is None:
-                        raise RuntimeError("SessionKeyProvider not initialized") from None
-                    self._key_provider.invalidate_cache(session_id)
-
-                    try:
-                        session_key = await self._key_provider.get_session_key(session_id)
-                        context["session_key"] = session_key
-                        processing_service = self.registry.get_service(EventProcessingService)
-                        await processing_service.process_event(event, context)
-                    except Exception as retry_error:
-                        logger.error("Retry failed for job %s: %s", job_id, retry_error)
-                        raise InvalidEventError(
-                            status="invalid_session_key",
-                            reason=f"Session key invalid: {str(e)}",
-                        ) from e
-                else:
+                if e.response.status_code != 403:
                     raise
+                await self._retry_with_fresh_key(event, session_id, job_id)
 
             except Exception as e:
                 logger.exception("Unexpected error processing job %s: %s", job_id, e)
 
-    def _convert_to_cloud_event(self, job_data: dict[str, Any]) -> GenericCloudEvent:
-        """Convert job notification to CloudEvent format.
+    def _require_key_provider(self) -> SessionKeyProvider:
+        if self._key_provider is None:
+            raise RuntimeError("SessionKeyProvider not initialized")
+        return self._key_provider
+
+    def _require_api_client(self) -> SessionsApiClient:
+        if self._api_client is None:
+            raise RuntimeError("SessionsApiClient not initialized")
+        return self._api_client
+
+    def _build_context(self, session_id: UUID, job_id: UUID, session_key: str) -> dict[str, Any]:
+        return {
+            "session_id": str(session_id),
+            "job_id": str(job_id),
+            "session_key": session_key,
+            "sessions_api_client": self._api_client,
+            "sessions_key_provider": self._key_provider,
+        }
+
+    async def _cancel_invalid_job(self, session_id: UUID, job_id: UUID, error: InvalidEventError) -> None:
+        logger.error("Invalid job %s: %s. Cancelling.", job_id, error)
+        try:
+            session_key = await self._require_key_provider().get_session_key(session_id)
+            await self._require_api_client().cancel_job(
+                session_id=session_id,
+                job_id=job_id,
+                session_key=session_key,
+                reason=f"Invalid event: {error}",
+            )
+        except Exception as cancel_error:
+            logger.error("Failed to cancel job %s: %s", job_id, cancel_error)
+
+    async def _retry_with_fresh_key(self, event: GenericCloudEvent, session_id: UUID, job_id: UUID) -> None:
+        # A 403 from a handler means the cached session key is stale. Invalidate and retry
+        # once through the SAME dispatch seam as the happy path (no separate code path).
+        logger.error("Invalid session key for session %s", session_id)
+        key_provider = self._require_key_provider()
+        key_provider.invalidate_cache(session_id)
+        try:
+            session_key = await key_provider.get_session_key(session_id)
+            context = self._build_context(session_id, job_id, session_key)
+            await self._dispatch_cloud_event(event, context)
+        except Exception as retry_error:
+            logger.error("Retry failed for job %s: %s", job_id, retry_error)
+            raise InvalidEventError(
+                status="invalid_session_key",
+                reason=f"Session key invalid: {retry_error}",
+            ) from retry_error
+
+    def _convert_to_cloud_event(self, notification: JobNotification) -> GenericCloudEvent:
+        """Convert a job notification to CloudEvent format.
 
         Args:
-            job_data: Job notification data from SSE
+            notification: Parsed job notification
 
         Returns:
-            GenericCloudEvent with job data
+            GenericCloudEvent with the full job payload as ``data``
         """
-        job_type = job_data["job_type"]
-        event_type = f"sessions.job.created.{job_type}"
-
-        return GenericCloudEvent(
-            specversion="1.0",
-            id=job_data["job_id"],
-            type=event_type,
-            source="/sessions-service",
-            subject=job_data["session_id"],
-            time=job_data.get("created_at"),
-            datacontenttype="application/json",
-            data=job_data,
-        )
+        event_type = f"sessions.job.created.{notification.job_type}"
+        kwargs: dict[str, Any] = {
+            "specversion": "1.0",
+            "id": str(notification.job_id),
+            "type": event_type,
+            "source": "/sessions-service",
+            "subject": str(notification.session_id),
+            "datacontenttype": "application/json",
+            "data": notification.payload(),
+        }
+        # Only set `time` when present — GenericCloudEvent rejects a None time; omitting it
+        # lets the model apply its default timestamp.
+        if notification.created_at is not None:
+            kwargs["time"] = notification.created_at
+        return GenericCloudEvent(**kwargs)

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -361,7 +361,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
     ) -> None:
         # A 403 from a handler means the cached session key is stale. Invalidate and retry
         # once through the SAME dispatch seam as the happy path (no separate code path).
-        logger.error("Invalid session key for session %s", session_id)
+        logger.warning("Stale session key for session %s; refreshing and retrying", session_id)
         key_provider = self._require_key_provider()
         key_provider.invalidate_cache(session_id)
         try:

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -159,9 +159,11 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         # v0.4.0 gates the stream on registration — register (idempotent) before every
         # connect attempt. On a legacy server this is a no-op (404 -> False); on a hard
         # failure it raises and the reconnect loop (in _consume_sse_stream) backs off.
-        await self._api_client.register_agent(
+        if self._agent_id is None:
+            raise RuntimeError("SessionsBus not started: agent_id is not set")
+        await self._require_api_client().register_agent(
             agent_id=self._agent_id,
-            agent_type=self._agent_type,
+            agent_type=self._agent_type or "",
             capabilities=self._capabilities,
         )
 

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -107,7 +107,13 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         )
 
     async def on_shutdown(self) -> None:
-        """Close the SSE connection and clean up resources."""
+        """Stop the stream, drain in-flight jobs, then unregister.
+
+        The order is deliberate: setting the shutdown event stops the consumer from
+        accepting new jobs, in-flight jobs are given a bounded window to finish, and
+        only then do we unregister — so the registration is never pulled out from
+        under a job that is still reporting results.
+        """
         logger.info("SessionsBus closing...")
 
         self._shutdown_event.set()
@@ -119,7 +125,39 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             except asyncio.CancelledError:
                 logger.info("SSE task cancelled")
 
+        await self._drain_inflight_jobs()
+
+        if self._api_client is not None and self._agent_id:
+            # Cleanup must never fail the shutdown; unregister_agent is best-effort but
+            # guard here too so a mocked/overridden client cannot break teardown.
+            try:
+                await self._api_client.unregister_agent(self._agent_id)
+            except Exception as e:
+                logger.warning("Unregister on shutdown failed: %s", e)
+
         logger.info("SessionsBus closed")
+
+    async def _drain_inflight_jobs(self) -> None:
+        """Wait for in-flight job tasks to finish, bounded by ``job_timeout``.
+
+        Jobs are launched fire-and-forget from the SSE loop; without this drain they
+        would be orphaned on shutdown. Tasks still running after the timeout are
+        cancelled so shutdown cannot hang.
+        """
+        if not self._inflight_tasks:
+            return
+        pending = list(self._inflight_tasks)
+        logger.info("Draining %d in-flight job(s) (timeout=%ds)", len(pending), self._job_timeout)
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=self._job_timeout,
+            )
+        except TimeoutError:
+            logger.warning("Drain timeout — cancelling %d in-flight job(s)", len(pending))
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
 
     async def _consume_sse_stream(self) -> None:
         """Connect to the SSE endpoint and process events with reconnection logic."""

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -154,6 +154,15 @@ class SessionsBus(Component, CloudEventProcessorMixin):
 
     async def _connect_and_consume(self) -> None:
         """Establish SSE connection and consume events."""
+        # v0.4.0 gates the stream on registration — register (idempotent) before every
+        # connect attempt. On a legacy server this is a no-op (404 -> False); on a hard
+        # failure it raises and the reconnect loop (in _consume_sse_stream) backs off.
+        await self._api_client.register_agent(
+            agent_id=self._agent_id,
+            agent_type=self._agent_type,
+            capabilities=self._capabilities,
+        )
+
         url = f"{self._base_url}/jobs/stream/sse"
         params: dict[str, Any] = {"agent_id": self._agent_id}
 

--- a/src/blueprint/agents/models/sessions.py
+++ b/src/blueprint/agents/models/sessions.py
@@ -1,0 +1,27 @@
+"""Domain models for the sessions service integration."""
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class JobNotification(BaseModel):
+    """A job dispatch notification received over the sessions SSE stream.
+
+    Parsed once at the SSE boundary so field names and presence rules live in one
+    place instead of being read ad hoc as ``dict`` keys throughout the bus. Extra
+    keys in the payload are preserved (``extra="allow"``) and flow through to the
+    CloudEvent ``data``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    session_id: UUID
+    job_id: UUID
+    job_type: str
+    created_at: str | None = None
+
+    def payload(self) -> dict[str, Any]:
+        """The full notification as a JSON-serialisable dict (UUIDs as strings)."""
+        return self.model_dump(mode="json")

--- a/src/blueprint/agents/services/sessions/api_client.py
+++ b/src/blueprint/agents/services/sessions/api_client.py
@@ -225,3 +225,36 @@ class SessionsApiClient(ServiceBase):
         job_data = response.json()
         logger.info("Job cancelled successfully: job_id=%s", job_id)
         return job_data
+
+    async def register_agent(
+        self,
+        agent_id: str,
+        agent_type: str,
+        capabilities: list[str],
+        version: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Register the agent with the sessions dispatch registry (idempotent).
+
+        v0.4.0 gates ``GET /jobs/stream/sse`` on a prior registration. Returns True
+        when the server accepted it (200/201). Returns False when the server is a
+        legacy (< v0.4.0) instance without the endpoint (404) — the caller may still
+        open the stream. Raises on any other non-2xx so the reconnect loop backs off.
+        """
+        payload: dict[str, Any] = {"agent_id": agent_id, "agent_type": agent_type, "capabilities": capabilities}
+        if version is not None:
+            payload["version"] = version
+        if metadata:
+            payload["metadata"] = metadata
+
+        response = await self._request("POST", "/agents/register", json=payload)
+
+        if response.status_code == 404:
+            logger.warning("Sessions service has no /agents/register (legacy < v0.4.0); proceeding without registration")
+            return False
+
+        if response.status_code >= 400:
+            logger.error("Agent registration failed: status=%d body=%s", response.status_code, response.text)
+        response.raise_for_status()
+        logger.info("Agent registered: agent_id=%s (status=%d)", agent_id, response.status_code)
+        return True

--- a/src/blueprint/agents/services/sessions/api_client.py
+++ b/src/blueprint/agents/services/sessions/api_client.py
@@ -6,7 +6,7 @@ and session key management.
 """
 
 import logging
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 import httpx
@@ -65,7 +65,7 @@ class SessionsApiClient(ServiceBase):
 
     async def _request(
         self,
-        method: str,
+        method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
         path: str,
         *,
         session_key: str | None = None,
@@ -87,7 +87,9 @@ class SessionsApiClient(ServiceBase):
         if json is not None:
             kwargs["json"] = json
 
-        method_fn = getattr(self._client, method.lower())
+        method_fn = getattr(self._client, method.lower(), None)
+        if method_fn is None:
+            raise ValueError(f"Unsupported HTTP method: {method!r}")
         return await method_fn(url, **kwargs)
 
     async def start_job(

--- a/src/blueprint/agents/services/sessions/api_client.py
+++ b/src/blueprint/agents/services/sessions/api_client.py
@@ -63,6 +63,33 @@ class SessionsApiClient(ServiceBase):
             await self._client.aclose()
             logger.info("SessionsApiClient HTTP client closed")
 
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        session_key: str | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Issue an authenticated request to the sessions service.
+
+        Owns the client-initialised guard, URL assembly, and the optional
+        X-Session-Key header. Returns the raw Response so callers decide how to treat
+        status codes (registration branches on 404 rather than always raising).
+        """
+        if not self._client:
+            raise ValueError("SessionsApiClient not initialized. Call on_startup() first.")
+
+        url = f"{self._base_url}{path}"
+        kwargs: dict[str, Any] = {}
+        if session_key is not None:
+            kwargs["headers"] = {"X-Session-Key": session_key}
+        if json is not None:
+            kwargs["json"] = json
+
+        method_fn = getattr(self._client, method.lower())
+        return await method_fn(url, **kwargs)
+
     async def start_job(
         self,
         session_id: UUID,
@@ -85,21 +112,16 @@ class SessionsApiClient(ServiceBase):
             httpx.HTTPStatusError: If the request fails
             ValueError: If client not initialized
         """
-        if not self._client:
-            raise ValueError("SessionsApiClient not initialized. Call on_startup() first.")
-
-        url = f"{self._base_url}/sessions/{session_id}/jobs/{job_id}/start"
-        payload = {"agent_id": agent_id}
-        headers = {"X-Session-Key": session_key}
-
         logger.info("Starting job: session_id=%s, job_id=%s, agent_id=%s", session_id, job_id, agent_id)
-
-        response = await self._client.post(url, json=payload, headers=headers)
+        response = await self._request(
+            "POST",
+            f"/sessions/{session_id}/jobs/{job_id}/start",
+            session_key=session_key,
+            json={"agent_id": agent_id},
+        )
         response.raise_for_status()
-
         job_data = response.json()
         logger.info("Job started successfully: job_id=%s", job_id)
-
         return job_data
 
     async def get_job_detail(
@@ -122,14 +144,12 @@ class SessionsApiClient(ServiceBase):
             httpx.HTTPStatusError: If the request fails
             ValueError: If client not initialized
         """
-        if not self._client:
-            raise ValueError("SessionsApiClient not initialized. Call on_startup() first.")
-
-        url = f"{self._base_url}/sessions/{session_id}/jobs/{job_id}"
-        headers = {"X-Session-Key": session_key}
-
         logger.debug("Fetching job detail: session_id=%s, job_id=%s", session_id, job_id)
-        response = await self._client.get(url, headers=headers)
+        response = await self._request(
+            "GET",
+            f"/sessions/{session_id}/jobs/{job_id}",
+            session_key=session_key,
+        )
         response.raise_for_status()
         job_data = response.json()
         logger.debug("Job detail fetched: job_id=%s", job_id)
@@ -157,21 +177,16 @@ class SessionsApiClient(ServiceBase):
             httpx.HTTPStatusError: If the request fails
             ValueError: If client not initialized
         """
-        if not self._client:
-            raise ValueError("SessionsApiClient not initialized. Call on_startup() first.")
-
-        url = f"{self._base_url}/sessions/{session_id}/jobs/{job_id}/complete"
-        headers = {"X-Session-Key": session_key}
-        payload = {"result": result}
-
         logger.info("Completing job: session_id=%s, job_id=%s", session_id, job_id)
-
-        response = await self._client.post(url, json=payload, headers=headers)
+        response = await self._request(
+            "POST",
+            f"/sessions/{session_id}/jobs/{job_id}/complete",
+            session_key=session_key,
+            json={"result": result},
+        )
         response.raise_for_status()
-
         job_data = response.json()
         logger.info("Job completed successfully: job_id=%s", job_id)
-
         return job_data
 
     async def cancel_job(
@@ -196,19 +211,15 @@ class SessionsApiClient(ServiceBase):
             httpx.HTTPStatusError: If the request fails
             ValueError: If client not initialized
         """
-        if not self._client:
-            raise ValueError("SessionsApiClient not initialized. Call on_startup() first.")
-
-        url = f"{self._base_url}/sessions/{session_id}/jobs/{job_id}/cancel"
-        headers = {"X-Session-Key": session_key}
         payload = {"reason": reason} if reason else {}
-
         logger.warning("Cancelling job: session_id=%s, job_id=%s, reason=%s", session_id, job_id, reason)
-
-        response = await self._client.post(url, json=payload, headers=headers)
+        response = await self._request(
+            "POST",
+            f"/sessions/{session_id}/jobs/{job_id}/cancel",
+            session_key=session_key,
+            json=payload,
+        )
         response.raise_for_status()
-
         job_data = response.json()
         logger.info("Job cancelled successfully: job_id=%s", job_id)
-
         return job_data

--- a/src/blueprint/agents/services/sessions/api_client.py
+++ b/src/blueprint/agents/services/sessions/api_client.py
@@ -229,7 +229,7 @@ class SessionsApiClient(ServiceBase):
     async def register_agent(
         self,
         agent_id: str,
-        agent_type: str,
+        agent_type: str | None,
         capabilities: list[str],
         version: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -240,8 +240,14 @@ class SessionsApiClient(ServiceBase):
         when the server accepted it (200/201). Returns False when the server is a
         legacy (< v0.4.0) instance without the endpoint (404) — the caller may still
         open the stream. Raises on any other non-2xx so the reconnect loop backs off.
+
+        ``agent_type`` is omitted from the payload when ``None`` (as with ``version``
+        and ``metadata``); the server rejects a missing required field loudly rather
+        than silently accepting an empty string.
         """
-        payload: dict[str, Any] = {"agent_id": agent_id, "agent_type": agent_type, "capabilities": capabilities}
+        payload: dict[str, Any] = {"agent_id": agent_id, "capabilities": capabilities}
+        if agent_type is not None:
+            payload["agent_type"] = agent_type
         if version is not None:
             payload["version"] = version
         if metadata:

--- a/src/blueprint/agents/services/sessions/api_client.py
+++ b/src/blueprint/agents/services/sessions/api_client.py
@@ -258,3 +258,15 @@ class SessionsApiClient(ServiceBase):
         response.raise_for_status()
         logger.info("Agent registered: agent_id=%s (status=%d)", agent_id, response.status_code)
         return True
+
+    async def unregister_agent(self, agent_id: str) -> None:
+        """Best-effort graceful deregistration (idempotent DELETE). Never raises.
+
+        Called on shutdown; a failure here must not prevent a clean shutdown, so all
+        exceptions (network error, 404 on legacy, closed client) are swallowed.
+        """
+        try:
+            response = await self._request("DELETE", f"/agents/{agent_id}")
+            logger.info("Agent unregistered: agent_id=%s (status=%d)", agent_id, response.status_code)
+        except Exception as e:
+            logger.warning("Graceful unregister failed for agent_id=%s: %s", agent_id, e)

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -368,3 +368,52 @@ class TestDispatchSseEvent:
         with caplog.at_level("WARNING"):
             sessions_bus._dispatch_sse_event(sse)
         assert "Unknown SSE event type: message" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# on_shutdown — drain + unregister
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownDrainAndUnregister:
+    async def test_unregisters_after_draining(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._agent_id = "agent-001"
+        bus._api_client.unregister_agent = AsyncMock()
+
+        async def _job() -> None:
+            await asyncio.sleep(0.01)
+
+        task = asyncio.create_task(_job())
+        bus._inflight_tasks.add(task)
+        task.add_done_callback(bus._inflight_tasks.discard)
+
+        await bus.on_shutdown()
+
+        assert task.done()
+        bus._api_client.unregister_agent.assert_awaited_once_with("agent-001")
+
+    async def test_drain_timeout_cancels_and_still_unregisters(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._agent_id = "agent-001"
+        bus._job_timeout = 0  # force immediate drain timeout
+        bus._api_client.unregister_agent = AsyncMock()
+
+        async def _slow_job() -> None:
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(_slow_job())
+        bus._inflight_tasks.add(task)
+        task.add_done_callback(bus._inflight_tasks.discard)
+
+        await bus.on_shutdown()
+
+        assert task.cancelled()
+        bus._api_client.unregister_agent.assert_awaited_once()
+
+    async def test_unregister_failure_does_not_raise(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._agent_id = "agent-001"
+        bus._api_client.unregister_agent = AsyncMock(side_effect=RuntimeError("boom"))
+        # on_shutdown must never propagate a cleanup failure.
+        await bus.on_shutdown()

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -361,3 +361,10 @@ class TestDispatchSseEvent:
             started_sessions_bus._dispatch_sse_event(sse)
         assert "Error processing SSE event" in caplog.text
         assert len(started_sessions_bus._inflight_tasks) == 0
+
+    def test_message_event_with_data_warns(self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture) -> None:
+        # A `message` frame WITH a payload is not a keepalive — it should still warn.
+        sse = SimpleNamespace(event="message", data='{"x": 1}')
+        with caplog.at_level("WARNING"):
+            sessions_bus._dispatch_sse_event(sse)
+        assert "Unknown SSE event type: message" in caplog.text

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -235,9 +235,7 @@ class TestProcessJobNotification:
 
         assert "Job remains pending" in caplog.text
 
-    async def test_403_invalidates_cache_and_retries(
-        self, started_sessions_bus: SessionsBus, notification: JobNotification
-    ) -> None:
+    async def test_403_invalidates_cache_and_retries(self, started_sessions_bus: SessionsBus, notification: JobNotification) -> None:
         response_mock = MagicMock()
         response_mock.status_code = 403
         http_err = httpx.HTTPStatusError("403", request=MagicMock(), response=response_mock)
@@ -326,18 +324,14 @@ class TestRegisterBeforeConnect:
 
 
 class TestDispatchSseEvent:
-    def test_keepalive_message_frame_is_debug_not_warning(
-        self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_keepalive_message_frame_is_debug_not_warning(self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture) -> None:
         sse = SimpleNamespace(event="message", data="")
         with caplog.at_level("DEBUG"):
             sessions_bus._dispatch_sse_event(sse)
         assert "keepalive" in caplog.text.lower()
         assert "Unknown SSE event type" not in caplog.text
 
-    def test_named_unknown_event_with_payload_warns(
-        self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_named_unknown_event_with_payload_warns(self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture) -> None:
         sse = SimpleNamespace(event="surprise", data="{}")
         with caplog.at_level("WARNING"):
             sessions_bus._dispatch_sse_event(sse)
@@ -347,15 +341,14 @@ class TestDispatchSseEvent:
         # async so a running event loop exists for asyncio.create_task; the assertion runs
         # before the loop yields to the scheduled coroutine, so the task is still tracked.
         started_sessions_bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
-        payload = '{"session_id": "00000000-0000-0000-0000-000000000001", ' \
-                  '"job_id": "00000000-0000-0000-0000-000000000002", "job_type": "t"}'
+        payload = (
+            '{"session_id": "00000000-0000-0000-0000-000000000001", ' '"job_id": "00000000-0000-0000-0000-000000000002", "job_type": "t"}'
+        )
         sse = SimpleNamespace(event="job_created", data=payload)
         started_sessions_bus._dispatch_sse_event(sse)
         assert len(started_sessions_bus._inflight_tasks) == 1
 
-    def test_malformed_job_payload_is_logged_and_skipped(
-        self, started_sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_malformed_job_payload_is_logged_and_skipped(self, started_sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture) -> None:
         sse = SimpleNamespace(event="job_created", data='{"missing": "ids"}')
         with caplog.at_level("ERROR"):
             started_sessions_bus._dispatch_sse_event(sse)

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -310,3 +310,28 @@ class TestProcessJobNotification:
             await started_sessions_bus._process_job_notification(job_data)
 
         assert "Unexpected error" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _connect_and_consume — registration gate
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterBeforeConnect:
+    async def test_registers_before_opening_stream(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._base_url = "http://sessions-svc"
+        bus._agent_id = "agent-001"
+        bus._agent_type = "transcription"
+        bus._capabilities = ["transcribe"]
+        bus._api_key = "secret"
+        bus._api_client.register_agent = AsyncMock(side_effect=RuntimeError("register-first"))
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse") as mock_sse:
+            with pytest.raises(RuntimeError, match="register-first"):
+                await bus._connect_and_consume()
+            mock_sse.assert_not_called()  # stream is never opened when registration fails
+
+        bus._api_client.register_agent.assert_awaited_once_with(
+            agent_id="agent-001", agent_type="transcription", capabilities=["transcribe"]
+        )

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -343,7 +343,7 @@ class TestDispatchSseEvent:
         # before the loop yields to the scheduled coroutine, so the task is still tracked.
         started_sessions_bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
         payload = (
-            '{"session_id": "00000000-0000-0000-0000-000000000001", ' '"job_id": "00000000-0000-0000-0000-000000000002", "job_type": "t"}'
+            '{"session_id": "00000000-0000-0000-0000-000000000001", "job_id": "00000000-0000-0000-0000-000000000002", "job_type": "t"}'
         )
         sse = SimpleNamespace(event="job_created", data=payload)
         started_sessions_bus._dispatch_sse_event(sse)

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import httpx
 import pytest
+from httpx_sse import SSEError
 
 from blueprint.agents.io.api.eventing.sessions_bus import SessionsBus
 from blueprint.agents.models.errors import InvalidEventError, RetryableHandlerError
@@ -410,3 +411,97 @@ class TestShutdownDrainAndUnregister:
         bus._api_client.unregister_agent = AsyncMock(side_effect=RuntimeError("boom"))
         # on_shutdown must never propagate a cleanup failure.
         await bus.on_shutdown()
+
+
+# ---------------------------------------------------------------------------
+# _connect_and_consume — end-to-end register/connect lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _EmptyAsyncIter:
+    """An async iterator that yields no SSE events (a clean, immediately-closed stream)."""
+
+    def __aiter__(self) -> "_EmptyAsyncIter":
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _RaisingAsyncIter:
+    """An async iterator whose first iteration raises (simulates a rejected stream)."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def __aiter__(self) -> "_RaisingAsyncIter":
+        return self
+
+    async def __anext__(self):
+        raise self._exc
+
+
+def _mock_sse_context(event_source: MagicMock) -> MagicMock:
+    """Build an async-context-manager stand-in for aconnect_sse(...) yielding event_source."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=event_source)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _connectable_bus(bus: SessionsBus) -> SessionsBus:
+    bus._base_url = "http://sessions-svc"
+    bus._agent_id = "agent-001"
+    bus._agent_type = "transcription"
+    bus._capabilities = ["transcribe"]
+    bus._api_key = "secret"
+    return bus
+
+
+class TestConnectLifecycle:
+    async def test_reconnect_re_registers(self, started_sessions_bus: SessionsBus) -> None:
+        # The reconnect loop re-invokes _connect_and_consume; each invocation must re-register.
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)):
+            await bus._connect_and_consume()
+            await bus._connect_and_consume()
+
+        assert bus._api_client.register_agent.await_count == 2
+
+    async def test_legacy_server_still_opens_stream(self, started_sessions_bus: SessionsBus) -> None:
+        # A legacy (< v0.4.0) server returns 404 -> register_agent returns False; the stream still opens.
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=False)
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)) as mock_sse:
+            await bus._connect_and_consume()
+
+        mock_sse.assert_called_once()
+
+    async def test_sse_rejection_logs_status_and_body(self, started_sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture) -> None:
+        # A non-event-stream response (e.g. the 403 dispatch-gate JSON) raises SSEError; the real
+        # status and body must be logged before the error propagates into the reconnect backoff.
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+
+        response = MagicMock()
+        response.status_code = 403
+        response.aread = AsyncMock(return_value=b'{"detail": "agent not registered"}')
+        event_source = MagicMock()
+        event_source.response = response
+        event_source.aiter_sse = lambda: _RaisingAsyncIter(SSEError("bad content-type"))
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)):
+            with caplog.at_level("ERROR"), pytest.raises(SSEError):
+                await bus._connect_and_consume()
+
+        assert "SSE stream rejected: status=403" in caplog.text
+        assert "agent not registered" in caplog.text

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -1,8 +1,9 @@
 """Unit tests for SessionsBus."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -10,6 +11,7 @@ import pytest
 from blueprint.agents.io.api.eventing.sessions_bus import SessionsBus
 from blueprint.agents.models.errors import InvalidEventError, RetryableHandlerError
 from blueprint.agents.models.result import ProcessingResult, ProcessingStatus
+from blueprint.agents.models.sessions import JobNotification
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -53,13 +55,13 @@ def started_sessions_bus(sessions_bus: SessionsBus) -> SessionsBus:
 
 
 @pytest.fixture
-def job_data() -> dict:
-    return {
-        "session_id": str(uuid4()),
-        "job_id": str(uuid4()),
-        "job_type": "transcription",
-        "created_at": "2024-01-01T00:00:00Z",
-    }
+def notification() -> JobNotification:
+    return JobNotification(
+        session_id=uuid4(),
+        job_id=uuid4(),
+        job_type="transcription",
+        created_at="2024-01-01T00:00:00Z",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -131,45 +133,40 @@ class TestOnShutdown:
 # ---------------------------------------------------------------------------
 
 
-def _job_data_with_time(**overrides: str) -> dict:
-    """Build minimal job data that includes the required created_at timestamp."""
-    base = {
-        "session_id": str(uuid4()),
-        "job_id": str(uuid4()),
-        "job_type": "transcription",
-        "created_at": "2024-01-01T00:00:00Z",
-    }
-    base.update(overrides)
-    return base
-
-
 class TestConvertToCloudEvent:
+    def _n(self, **overrides) -> JobNotification:
+        base = {
+            "session_id": uuid4(),
+            "job_id": uuid4(),
+            "job_type": "transcription",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+        base.update(overrides)
+        return JobNotification(**base)
+
     def test_event_type_includes_job_type(self, sessions_bus: SessionsBus) -> None:
-        data = _job_data_with_time(job_type="analysis")
-        event = sessions_bus._convert_to_cloud_event(data)
+        event = sessions_bus._convert_to_cloud_event(self._n(job_type="analysis"))
         assert event.type == "sessions.job.created.analysis"
 
     def test_event_id_is_job_id(self, sessions_bus: SessionsBus) -> None:
-        job_id = str(uuid4())
-        data = _job_data_with_time(job_id=job_id)
-        event = sessions_bus._convert_to_cloud_event(data)
-        assert event.id == job_id
+        job_id = uuid4()
+        event = sessions_bus._convert_to_cloud_event(self._n(job_id=job_id))
+        assert event.id == str(job_id)
 
     def test_subject_is_session_id(self, sessions_bus: SessionsBus) -> None:
-        session_id = str(uuid4())
-        data = _job_data_with_time(session_id=session_id)
-        event = sessions_bus._convert_to_cloud_event(data)
-        assert event.subject == session_id
+        session_id = uuid4()
+        event = sessions_bus._convert_to_cloud_event(self._n(session_id=session_id))
+        assert event.subject == str(session_id)
 
     def test_source_is_sessions_service(self, sessions_bus: SessionsBus) -> None:
-        data = _job_data_with_time()
-        event = sessions_bus._convert_to_cloud_event(data)
+        event = sessions_bus._convert_to_cloud_event(self._n())
         assert event.source == "/sessions-service"
 
-    def test_data_payload_equals_job_data(self, sessions_bus: SessionsBus) -> None:
-        data = _job_data_with_time(job_type="analysis")
-        event = sessions_bus._convert_to_cloud_event(data)
-        assert event.data == data
+    def test_data_payload_contains_job_fields(self, sessions_bus: SessionsBus) -> None:
+        n = self._n(job_type="analysis")
+        event = sessions_bus._convert_to_cloud_event(n)
+        assert event.data["job_type"] == "analysis"
+        assert event.data["session_id"] == str(n.session_id)
 
 
 # ---------------------------------------------------------------------------
@@ -181,7 +178,7 @@ class TestProcessJobNotification:
     async def test_no_handler_found_is_logged(
         self,
         started_sessions_bus: SessionsBus,
-        job_data: dict,
+        notification: JobNotification,
         mock_registry: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
@@ -193,28 +190,28 @@ class TestProcessJobNotification:
         started_sessions_bus._dispatch_cloud_event = AsyncMock(return_value=result)  # type: ignore[method-assign]
 
         with caplog.at_level("WARNING"):
-            await started_sessions_bus._process_job_notification(job_data)
+            await started_sessions_bus._process_job_notification(notification)
 
         assert "No handler found" in caplog.text
 
     async def test_invalid_event_error_cancels_job(
         self,
         started_sessions_bus: SessionsBus,
-        job_data: dict,
+        notification: JobNotification,
     ) -> None:
         err = InvalidEventError(status="bad_data", reason="missing field")
         started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=err)  # type: ignore[method-assign]
 
-        await started_sessions_bus._process_job_notification(job_data)
+        await started_sessions_bus._process_job_notification(notification)
 
         started_sessions_bus._api_client.cancel_job.assert_awaited_once()
         call_kwargs = started_sessions_bus._api_client.cancel_job.call_args.kwargs
-        assert call_kwargs["job_id"] == UUID(job_data["job_id"])
+        assert call_kwargs["job_id"] == notification.job_id
 
     async def test_invalid_event_error_cancel_failure_is_swallowed(
         self,
         started_sessions_bus: SessionsBus,
-        job_data: dict,
+        notification: JobNotification,
     ) -> None:
         started_sessions_bus._dispatch_cloud_event = AsyncMock(  # type: ignore[method-assign]
             side_effect=InvalidEventError(status="bad", reason="reason")
@@ -222,67 +219,53 @@ class TestProcessJobNotification:
         started_sessions_bus._api_client.cancel_job = AsyncMock(side_effect=RuntimeError("cancel failed"))
 
         # Should not raise — cancel failures are swallowed
-        await started_sessions_bus._process_job_notification(job_data)
+        await started_sessions_bus._process_job_notification(notification)
 
     async def test_retryable_error_is_logged_not_raised(
         self,
         started_sessions_bus: SessionsBus,
-        job_data: dict,
+        notification: JobNotification,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         err = RetryableHandlerError(status="transient", reason="downstream unavailable")
         started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=err)  # type: ignore[method-assign]
 
         with caplog.at_level("WARNING"):
-            await started_sessions_bus._process_job_notification(job_data)
+            await started_sessions_bus._process_job_notification(notification)
 
         assert "Job remains pending" in caplog.text
 
     async def test_403_invalidates_cache_and_retries(
-        self,
-        started_sessions_bus: SessionsBus,
-        job_data: dict,
-        mock_registry: MagicMock,
+        self, started_sessions_bus: SessionsBus, notification: JobNotification
     ) -> None:
         response_mock = MagicMock()
         response_mock.status_code = 403
         http_err = httpx.HTTPStatusError("403", request=MagicMock(), response=response_mock)
-        started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=http_err)  # type: ignore[method-assign]
-        mock_registry.get_service.return_value.process_event = AsyncMock(
-            return_value=ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
-        )
+        processed = ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
+        # First dispatch raises 403; the retry (same seam) succeeds.
+        started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=[http_err, processed])  # type: ignore[method-assign]
 
-        await started_sessions_bus._process_job_notification(job_data)
+        await started_sessions_bus._process_job_notification(notification)
 
         started_sessions_bus._key_provider.invalidate_cache.assert_called_once()
-        mock_registry.get_service.return_value.process_event.assert_awaited_once()
+        assert started_sessions_bus._dispatch_cloud_event.await_count == 2
 
     async def test_403_retry_failure_propagates_invalid_event_error(
-        self,
-        started_sessions_bus: SessionsBus,
-        job_data: dict,
-        mock_registry: MagicMock,
+        self, started_sessions_bus: SessionsBus, notification: JobNotification
     ) -> None:
-        """Exceptions raised inside an except clause propagate outside all peer handlers.
-
-        When the 403 retry fails, `raise InvalidEventError(...)` is executed inside
-        the `except httpx.HTTPStatusError` block. Python does not route this new
-        exception to other except clauses at the same level — it propagates out of
-        _process_job_notification entirely.
-        """
         response_mock = MagicMock()
         response_mock.status_code = 403
         http_err = httpx.HTTPStatusError("403", request=MagicMock(), response=response_mock)
-        started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=http_err)  # type: ignore[method-assign]
-        mock_registry.get_service.return_value.process_event = AsyncMock(side_effect=RuntimeError("still broken"))
-
+        started_sessions_bus._dispatch_cloud_event = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[http_err, RuntimeError("still broken")]
+        )
         with pytest.raises(InvalidEventError, match="Session key invalid"):
-            await started_sessions_bus._process_job_notification(job_data)
+            await started_sessions_bus._process_job_notification(notification)
 
     async def test_non_403_http_error_propagates(
         self,
         started_sessions_bus: SessionsBus,
-        job_data: dict,
+        notification: JobNotification,
     ) -> None:
         """Non-403 HTTPStatusError is re-raised and escapes _process_job_notification.
 
@@ -296,18 +279,18 @@ class TestProcessJobNotification:
         started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=http_err)  # type: ignore[method-assign]
 
         with pytest.raises(httpx.HTTPStatusError):
-            await started_sessions_bus._process_job_notification(job_data)
+            await started_sessions_bus._process_job_notification(notification)
 
     async def test_unexpected_error_is_logged_not_raised(
         self,
         started_sessions_bus: SessionsBus,
-        job_data: dict,
+        notification: JobNotification,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         started_sessions_bus._dispatch_cloud_event = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
 
         with caplog.at_level("ERROR"):
-            await started_sessions_bus._process_job_notification(job_data)
+            await started_sessions_bus._process_job_notification(notification)
 
         assert "Unexpected error" in caplog.text
 
@@ -335,3 +318,46 @@ class TestRegisterBeforeConnect:
         bus._api_client.register_agent.assert_awaited_once_with(
             agent_id="agent-001", agent_type="transcription", capabilities=["transcribe"]
         )
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_sse_event
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSseEvent:
+    def test_keepalive_message_frame_is_debug_not_warning(
+        self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sse = SimpleNamespace(event="message", data="")
+        with caplog.at_level("DEBUG"):
+            sessions_bus._dispatch_sse_event(sse)
+        assert "keepalive" in caplog.text.lower()
+        assert "Unknown SSE event type" not in caplog.text
+
+    def test_named_unknown_event_with_payload_warns(
+        self, sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sse = SimpleNamespace(event="surprise", data="{}")
+        with caplog.at_level("WARNING"):
+            sessions_bus._dispatch_sse_event(sse)
+        assert "Unknown SSE event type: surprise" in caplog.text
+
+    async def test_job_created_creates_tracked_task(self, started_sessions_bus: SessionsBus) -> None:
+        # async so a running event loop exists for asyncio.create_task; the assertion runs
+        # before the loop yields to the scheduled coroutine, so the task is still tracked.
+        started_sessions_bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
+        payload = '{"session_id": "00000000-0000-0000-0000-000000000001", ' \
+                  '"job_id": "00000000-0000-0000-0000-000000000002", "job_type": "t"}'
+        sse = SimpleNamespace(event="job_created", data=payload)
+        started_sessions_bus._dispatch_sse_event(sse)
+        assert len(started_sessions_bus._inflight_tasks) == 1
+
+    def test_malformed_job_payload_is_logged_and_skipped(
+        self, started_sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sse = SimpleNamespace(event="job_created", data='{"missing": "ids"}')
+        with caplog.at_level("ERROR"):
+            started_sessions_bus._dispatch_sse_event(sse)
+        assert "Error processing SSE event" in caplog.text
+        assert len(started_sessions_bus._inflight_tasks) == 0

--- a/tests/unit/agents/models/test_sessions.py
+++ b/tests/unit/agents/models/test_sessions.py
@@ -1,0 +1,38 @@
+"""Unit tests for sessions domain models."""
+
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from blueprint.agents.models.sessions import JobNotification
+
+_VALID = {
+    "session_id": "00000000-0000-0000-0000-000000000001",
+    "job_id": "00000000-0000-0000-0000-000000000002",
+    "job_type": "transcription",
+    "created_at": "2024-01-01T00:00:00Z",
+}
+
+
+class TestJobNotification:
+    def test_parses_and_types_ids(self) -> None:
+        n = JobNotification.model_validate(_VALID)
+        assert n.session_id == UUID("00000000-0000-0000-0000-000000000001")
+        assert n.job_id == UUID("00000000-0000-0000-0000-000000000002")
+        assert n.job_type == "transcription"
+
+    def test_created_at_optional(self) -> None:
+        data = {k: v for k, v in _VALID.items() if k != "created_at"}
+        assert JobNotification.model_validate(data).created_at is None
+
+    def test_missing_required_field_raises(self) -> None:
+        data = {k: v for k, v in _VALID.items() if k != "job_id"}
+        with pytest.raises(ValidationError):
+            JobNotification.model_validate(data)
+
+    def test_extra_keys_preserved_in_payload(self) -> None:
+        n = JobNotification.model_validate({**_VALID, "priority": "high"})
+        payload = n.payload()
+        assert payload["priority"] == "high"
+        assert payload["session_id"] == _VALID["session_id"]  # UUID serialised back to str

--- a/tests/unit/agents/services/sessions/conftest.py
+++ b/tests/unit/agents/services/sessions/conftest.py
@@ -34,6 +34,7 @@ def mock_http_client() -> AsyncMock:
     client = AsyncMock()
     client.get = AsyncMock(return_value=mock_response)
     client.post = AsyncMock(return_value=mock_response)
+    client.delete = AsyncMock(return_value=mock_response)
     client.aclose = AsyncMock()
     return client
 

--- a/tests/unit/agents/services/sessions/test_api_client.py
+++ b/tests/unit/agents/services/sessions/test_api_client.py
@@ -215,6 +215,13 @@ class TestRegisterAgent:
         assert payload["version"] == "1.2.3"
         assert payload["metadata"] == {"k": "v"}
 
+    async def test_agent_type_omitted_when_none(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        await started_api_client.register_agent("a", None, [])
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert "agent_type" not in payload
+        assert payload == {"agent_id": "a", "capabilities": []}
+
     async def test_raises_when_not_initialized(self, api_client) -> None:
         with pytest.raises(ValueError, match="not initialized"):
             await api_client.register_agent("a", "t", [])

--- a/tests/unit/agents/services/sessions/test_api_client.py
+++ b/tests/unit/agents/services/sessions/test_api_client.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 
 from blueprint.agents.services.sessions.api_client import SessionsApiClient
@@ -166,3 +167,54 @@ class TestCancelJob:
     async def test_raises_when_not_initialized(self, api_client: SessionsApiClient) -> None:
         with pytest.raises(ValueError, match="not initialized"):
             await api_client.cancel_job(_SESSION_ID, _JOB_ID, _SESSION_KEY)
+
+
+# ---------------------------------------------------------------------------
+# register_agent
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAgent:
+    async def test_posts_to_register_endpoint_with_body(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        await started_api_client.register_agent("agent-1", "analyser", ["classify"])
+        url = mock_http_client.post.call_args[0][0]
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert url.endswith("/agents/register")
+        assert payload == {"agent_id": "agent-1", "agent_type": "analyser", "capabilities": ["classify"]}
+
+    async def test_201_returns_true(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        assert await started_api_client.register_agent("a", "t", []) is True
+
+    async def test_200_returns_true(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 200
+        assert await started_api_client.register_agent("a", "t", []) is True
+
+    async def test_404_returns_false_and_does_not_raise(self, started_api_client, mock_http_client, caplog) -> None:
+        mock_http_client.post.return_value.status_code = 404
+        with caplog.at_level("WARNING"):
+            result = await started_api_client.register_agent("a", "t", [])
+        assert result is False
+        assert "legacy" in caplog.text.lower()
+        mock_http_client.post.return_value.raise_for_status.assert_not_called()
+
+    async def test_500_raises_and_logs_body(self, started_api_client, mock_http_client, caplog) -> None:
+        resp = mock_http_client.post.return_value
+        resp.status_code = 500
+        resp.text = "internal error detail"
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError("500", request=MagicMock(), response=resp)
+        with caplog.at_level("ERROR"), pytest.raises(httpx.HTTPStatusError):
+            await started_api_client.register_agent("a", "t", [])
+        assert "internal error detail" in caplog.text
+
+    async def test_optional_fields_included_when_given(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.post.return_value.status_code = 201
+        await started_api_client.register_agent("a", "t", [], version="1.2.3", metadata={"k": "v"})
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert payload["version"] == "1.2.3"
+        assert payload["metadata"] == {"k": "v"}
+
+    async def test_raises_when_not_initialized(self, api_client) -> None:
+        with pytest.raises(ValueError, match="not initialized"):
+            await api_client.register_agent("a", "t", [])

--- a/tests/unit/agents/services/sessions/test_api_client.py
+++ b/tests/unit/agents/services/sessions/test_api_client.py
@@ -218,3 +218,25 @@ class TestRegisterAgent:
     async def test_raises_when_not_initialized(self, api_client) -> None:
         with pytest.raises(ValueError, match="not initialized"):
             await api_client.register_agent("a", "t", [])
+
+
+# ---------------------------------------------------------------------------
+# unregister_agent
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisterAgent:
+    async def test_deletes_agent_endpoint(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.delete.return_value.status_code = 204
+        await started_api_client.unregister_agent("agent-1")
+        url = mock_http_client.delete.call_args[0][0]
+        assert url.endswith("/agents/agent-1")
+
+    async def test_swallows_errors(self, started_api_client, mock_http_client, caplog) -> None:
+        mock_http_client.delete.side_effect = httpx.ConnectError("boom")
+        with caplog.at_level("WARNING"):
+            await started_api_client.unregister_agent("agent-1")  # must not raise
+        assert "unregister failed" in caplog.text.lower()
+
+    async def test_swallows_uninitialized_client(self, api_client) -> None:
+        await api_client.unregister_agent("agent-1")  # must not raise


### PR DESCRIPTION
## Summary

Sessions service **v0.4.0** gates `GET /jobs/stream/sse` on the agent registry: it returns **403 (JSON)** unless the agent has first called `POST /agents/register`. `SessionsBus` connected straight to the stream, so after the v0.4.0 deploy every deployed agent fell into an infinite 5s reconnect loop. This PR makes `SessionsBus` register before streaming, and folds in the related keepalive-noise fix (#44).

- **Register before connect (#45):** `SessionsBus._connect_and_consume` now calls `SessionsApiClient.register_agent` before opening the stream. Because the reconnect loop re-invokes it, re-registration on every reconnect is automatic. A legacy (< v0.4.0) server that 404s the register call is handled as "proceed without registration". A hard registration failure raises into the existing backoff, and app-startup resilience is preserved (registration happens inside the background SSE task, not `on_startup`).
- **Surface the real rejection (#45):** an `SSEError` now logs the actual status + body instead of the opaque content-type error that cost most of the original diagnosis time.
- **Keepalive noise (#44):** SSE keepalive comment frames are no longer logged as `Unknown SSE event type: message` every 30s.
- **Graceful shutdown:** `on_shutdown` stops the stream, drains in-flight jobs (bounded by `job_timeout_seconds`, cancelling stragglers), then `DELETE /agents/{agent_id}` so the agent leaves the registry immediately instead of lapsing at TTL.

### Supporting refactors (from a Brooks-Lint review of the touched files)
- Shared `SessionsApiClient._request` helper (de-dupes the client guard + request boilerplate); new `register_agent` / `unregister_agent`.
- Typed `JobNotification` value object parsed once at the SSE boundary (replacing ad-hoc `dict` access).
- `_process_job_notification` split into a thin dispatcher + per-policy helpers; the 403 session-key retry now goes through the same `_dispatch_cloud_event` seam as the happy path (previously bypassed the mixin).

Design & plan: `docs/superpowers/specs/2026-07-06-sessions-agent-registration-design.md`, `docs/superpowers/plans/2026-07-06-sessions-agent-registration.md`.

Closes #45. Closes #44.

## Test Plan
- [x] 125 sessions-related unit tests pass, incl. the offline startup-resilience integration test.
- [x] New tests cover: register-before-connect gating, reconnect re-registration, legacy-404 (still opens stream), SSE-rejection diagnostics, keepalive-vs-message distinction (#44), and shutdown drain/unregister (incl. timeout-cancel).
- [x] `black --check`, `ruff check src/ tests/`, and `mypy` clean on all changed files.
- [ ] Reviewer: confirm behavior against a live sessions v0.4.0 instance.

### Notes for reviewers
- Pre-existing on `develop`, out of scope here: 2 `mypy` errors in `src/blueprint/agents/io/api/utilities/root.py` (guarded on the `fix/openapi-drop-blanket-rest-tag` branch), plus redis optional-dependency tests and `tests/integration/examples/` scaffolding checks that fail without the `[redis]` extra / example fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YugPZ21JYkB7p1E1xph4F