### PR TITLE
docs(changelog): consolidate pending entries under [0.6.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [Unreleased]
 
+## [0.6.2] - 2026-07-06
+
 ### Fixed
 - **`SessionsBus` registers with the dispatch registry before opening the SSE stream** (#45).
   Sessions v0.4.0 gates `GET /jobs/stream/sse` on a prior `POST /agents/register`; the bus now
@@ -15,10 +17,6 @@
   waits for in-flight jobs (bounded by `job_timeout_seconds`, cancelling stragglers), then calls
   `DELETE /agents/{agent_id}` so the agent leaves the registry immediately instead of lapsing at TTL.
 - Job notifications are parsed into a typed `JobNotification` model at the SSE boundary.
-
-## [0.6.4] - 2026-07-06
-
-### Changed
 - **Business REST routers no longer carry a blanket `rest` OpenAPI tag.** `_build_rest_endpoints` mounted every `with_rest_api` router with `include_router(..., tags=["rest"])`, which stamps a redundant `rest` tag onto *every* operation on top of its own per-operation tag — so the entire business API collapses into a single `rest` group in Swagger UI. Routers are now mounted without the blanket tag; operations group by their real resource tags (set via the `RestApiBase` decorators), and untagged routes fall under FastAPI's `default`. Presentation only — no route/path/schema change. Downstream services that relied on the `rest` grouping should tag their routes (most already do).
 
 ## [0.6.1] - 2026-06-10


### PR DESCRIPTION
## Summary
Aligns `CHANGELOG.md` with the package version (`pyproject` = **0.6.2**). Previously the SessionsBus work sat under `[Unreleased]` and the OpenAPI-tag fix was mislabelled `[0.6.4]` (skipping 0.6.2/0.6.3). Both are now merged into a single dated **`[0.6.2] - 2026-07-06`** section, with an empty `[Unreleased]` retained for future work.

- `[0.6.2]` **Fixed**: register-before-SSE (#45), keepalive log noise (#44).
- `[0.6.2]` **Changed**: shutdown drain/unregister, typed `JobNotification`, and the blanket-`rest`-tag removal (#48).
- Removed the incorrect `[0.6.4]` heading. No `pyproject` change needed (already 0.6.2).

Addresses the version-reconciliation checklist item on the `develop → main` release PR #54.

## Test Plan
- [x] Docs-only change; `## [` headers verified: `[Unreleased] → [0.6.2] - 2026-07-06 → [0.6.1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YugPZ21JYkB7p1E1xph4F