### PR TITLE
fix(sessions): reconcile pending jobs missed while disconnected (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **`SessionsBus` now reconciles jobs missed while disconnected** (#57). SSE is a live-only push
+  transport, so jobs created during a restart, redeploy, or stream gap were never delivered and
+  stayed `pending` on the server (observed: 9 `analyse.batch` jobs created before a reconnect that
+  were never picked up). On every (re)connect the bus now reconciles two ways: (1) a REST
+  **catch-up** — lists pending jobs for its capabilities (`GET /jobs?status=pending`) and dispatches
+  each through the normal job path (best-effort; de-duplicated by the handler's idempotency guards;
+  a listing failure never disturbs the live stream), and (2) **`Last-Event-ID` resume** — tracks the
+  last SSE event id and sends `last_event_id` on reconnect so a same-process stream gap replays from
+  the server ring buffer. A cold start omits `last_event_id` (catch-up covers it). Distinct follow-on
+  to #45. A job stranded in `running` by a crashed agent is recovered server-side
+  (avs.ai.idac.service-sessions#127) and then redelivered by this catch-up.
+
 ## [0.6.2] - 2026-07-06
 
 ### Fixed

--- a/docs/concepts/event-processing.md
+++ b/docs/concepts/event-processing.md
@@ -250,6 +250,16 @@ When `event_bus = "sessions"`, `AppBuilder.build()` wires three components autom
 > shutdown it drains in-flight jobs and unregisters (`DELETE /agents/{agent_id}`). Against a pre-v0.4.0
 > server the register call returns 404 and is skipped ("legacy, proceed without registration").
 
+> **Reconnect catch-up:** SSE only pushes jobs created *while connected*, so jobs created during a
+> restart, redeploy, or stream gap would otherwise be missed. On every (re)connect `SessionsBus`
+> reconciles in two ways: it resumes the stream with `Last-Event-ID` (the server replays missed
+> frames from its ring buffer on a same-process reconnect), and it runs a REST **catch-up** —
+> `GET /jobs?status=pending` for its capabilities — dispatching any pending jobs through the normal
+> handler path. Both feed the same idempotent handler, so a job that arrives via more than one route
+> is processed once. Catch-up is best-effort: a listing failure is logged and never disturbs the live
+> stream. A job stranded in `running` because its previous owner crashed is recovered server-side
+> (the sessions reaper re-pends it) and then redelivered by this catch-up.
+
 ```toml
 [default]
 event_bus = "sessions"

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -7,6 +7,7 @@ for processing via the CloudEventProcessorMixin dispatch pipeline.
 
 import asyncio
 import logging
+from collections.abc import Coroutine
 from typing import Any
 from uuid import UUID
 
@@ -43,6 +44,11 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         # SSE connection
         self._sse_task: asyncio.Task[None] | None = None
         self._shutdown_event: asyncio.Event = asyncio.Event()
+
+        # Last SSE event id seen, sent as `last_event_id` on reconnect so the server replays
+        # events missed during a same-process stream gap from its ring buffer. None until the
+        # first id-bearing frame (and after a process restart) — the REST catch-up covers that.
+        self._last_event_id: int | None = None
 
         # In-flight job tasks (tracked so shutdown can drain them, not orphan them)
         self._inflight_tasks: set[asyncio.Task[None]] = set()
@@ -211,12 +217,22 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             params["agent_type"] = self._agent_type
         if self._capabilities:
             params["capabilities"] = ",".join(self._capabilities)
+        # Resume from the last id we saw so a same-process reconnect replays missed events
+        # from the server ring buffer. Omitted on a cold start (None) — catch-up covers that.
+        if self._last_event_id is not None:
+            params["last_event_id"] = self._last_event_id
 
         headers = {"X-Api-Key": self._api_key}
 
         async with httpx.AsyncClient(timeout=None) as client:
             async with aconnect_sse(client, "GET", url, params=params, headers=headers) as event_source:
                 logger.info("SSE connection established")
+                # Subscribe-then-snapshot: the stream is open, so any job created from here on
+                # arrives live. Reconcile jobs created *before* now (restart/redeploy/gap) via a
+                # background REST catch-up; overlaps with replayed/live events are de-duplicated
+                # by the job handler's idempotency guards. Runs off the consume loop so it never
+                # blocks live delivery.
+                self._spawn_tracked(self._run_catch_up())
                 try:
                     async for sse in event_source.aiter_sse():
                         if self._shutdown_event.is_set():
@@ -230,9 +246,31 @@ class SessionsBus(Component, CloudEventProcessorMixin):
                     logger.error("SSE stream rejected: status=%d body=%s", resp.status_code, body)
                     raise
 
+    def _spawn_tracked(self, coro: Coroutine[Any, Any, None]) -> None:
+        """Launch *coro* as a tracked background task so shutdown can drain it.
+
+        Shared by the live ``job_created`` path and the reconnect catch-up so both feed the
+        same in-flight set (and therefore the same shutdown drain).
+        """
+        task = asyncio.create_task(coro)
+        self._inflight_tasks.add(task)
+        task.add_done_callback(self._inflight_tasks.discard)
+
+    def _track_event_id(self, sse: ServerSentEvent) -> None:
+        """Advance the resume cursor from a frame's ``id`` (server ids are monotonic ints)."""
+        raw = getattr(sse, "id", None)
+        if not raw:
+            return
+        try:
+            self._last_event_id = int(raw)
+        except (TypeError, ValueError):
+            logger.debug("Ignoring non-numeric SSE id: %r", raw)
+
     def _dispatch_sse_event(self, sse: ServerSentEvent) -> None:
         """Route a single SSE frame. Keepalive comment frames are ignored (#44)."""
         try:
+            self._track_event_id(sse)
+
             if sse.event == "connected":
                 logger.info("SSE connected event received")
 
@@ -243,9 +281,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
                     notification.job_id,
                     notification.job_type,
                 )
-                task = asyncio.create_task(self._handle_job_notification(notification))
-                self._inflight_tasks.add(task)
-                task.add_done_callback(self._inflight_tasks.discard)
+                self._spawn_tracked(self._handle_job_notification(notification))
 
             elif sse.event == "heartbeat":
                 logger.debug("SSE heartbeat received")
@@ -260,6 +296,45 @@ class SessionsBus(Component, CloudEventProcessorMixin):
 
         except Exception as e:
             logger.error("Error processing SSE event: %s", e, exc_info=True)
+
+    async def _run_catch_up(self) -> None:
+        """Reconcile jobs created while the agent was disconnected (restart / redeploy / gap).
+
+        SSE only delivers jobs created *while connected*; anything created before this stream
+        opened is pending on the server but was never pushed. List those over REST and dispatch
+        each through the same path as a live notification. Best-effort: a listing failure is
+        logged and swallowed so it never disturbs the live stream, and each summary is parsed
+        defensively so one bad row does not stop the rest. Overlap with replayed or live events
+        is de-duplicated by the job handler's idempotency guards.
+        """
+        if self._shutdown_event.is_set():
+            return
+        try:
+            summaries = await self._require_api_client().list_pending_jobs(self._capabilities)
+        except Exception as e:
+            logger.warning("Catch-up listing failed; missed jobs wait for the next reconnect: %s", e)
+            return
+        if not summaries:
+            return
+        logger.info("Catch-up: reconciling %d pending job(s) missed while disconnected", len(summaries))
+        for summary in summaries:
+            if self._shutdown_event.is_set():
+                break
+            try:
+                notification = self._notification_from_summary(summary)
+            except Exception as e:
+                logger.error("Skipping unparseable pending-job summary %r: %s", summary, e)
+                continue
+            self._spawn_tracked(self._handle_job_notification(notification))
+
+    def _notification_from_summary(self, summary: dict[str, Any]) -> JobNotification:
+        """Build a JobNotification from a REST ``JobSummary`` dict (its ``id`` is the job id)."""
+        return JobNotification(
+            session_id=summary["session_id"],
+            job_id=summary["id"],
+            job_type=summary["job_type"],
+            created_at=summary.get("created_at"),
+        )
 
     async def _handle_job_notification(self, notification: JobNotification) -> None:
         """Handle job notification with concurrency control.

--- a/src/blueprint/agents/services/sessions/api_client.py
+++ b/src/blueprint/agents/services/sessions/api_client.py
@@ -70,6 +70,7 @@ class SessionsApiClient(ServiceBase):
         *,
         session_key: str | None = None,
         json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> httpx.Response:
         """Issue an authenticated request to the sessions service.
 
@@ -86,6 +87,8 @@ class SessionsApiClient(ServiceBase):
             kwargs["headers"] = {"X-Session-Key": session_key}
         if json is not None:
             kwargs["json"] = json
+        if params is not None:
+            kwargs["params"] = params
 
         method_fn = getattr(self._client, method.lower(), None)
         if method_fn is None:
@@ -225,6 +228,35 @@ class SessionsApiClient(ServiceBase):
         job_data = response.json()
         logger.info("Job cancelled successfully: job_id=%s", job_id)
         return job_data
+
+    async def list_pending_jobs(self, job_types: list[str] | None = None) -> list[dict[str, Any]]:
+        """List pending jobs for reconnect catch-up.
+
+        SSE only pushes jobs created *while connected*; jobs created during a restart,
+        redeploy, or stream gap are never delivered. On (re)connect the bus reconciles
+        against this authoritative REST listing so those pending jobs are still picked up.
+
+        Queries ``GET /jobs?status=pending`` once per entry in ``job_types`` (the agent's
+        capabilities), or a single unfiltered query when it is empty/None — mirroring the
+        dispatch registry's "no capabilities = all job types" rule. Results are merged and
+        de-duplicated by job id. Returns the raw ``JobSummary`` dicts (``id``, ``session_id``,
+        ``job_type``, ``status``, ``created_at``, ``updated_at``).
+
+        Raises:
+            httpx.HTTPStatusError: If any listing request fails.
+            ValueError: If the client is not initialized.
+        """
+        queries: list[dict[str, str]] = (
+            [{"status": "pending", "job_type": jt} for jt in job_types] if job_types else [{"status": "pending"}]
+        )
+        merged: dict[str, dict[str, Any]] = {}
+        for params in queries:
+            response = await self._request("GET", "/jobs", params=params)
+            response.raise_for_status()
+            for summary in response.json():
+                merged[str(summary["id"])] = summary
+        logger.debug("Catch-up listing found %d pending job(s) for job_types=%s", len(merged), job_types or "<all>")
+        return list(merged.values())
 
     async def register_agent(
         self,

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -3,7 +3,7 @@
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -505,3 +505,137 @@ class TestConnectLifecycle:
 
         assert "SSE stream rejected: status=403" in caplog.text
         assert "agent not registered" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Reconnect catch-up (REST reconciliation of jobs missed while disconnected)
+# ---------------------------------------------------------------------------
+
+
+async def _drain_inflight(bus: SessionsBus) -> None:
+    """Await every task the bus spawned (catch-up task + the per-job tasks it creates)."""
+    while bus._inflight_tasks:
+        await asyncio.gather(*list(bus._inflight_tasks), return_exceptions=True)
+
+
+_JOB_1 = "11111111-1111-1111-1111-111111111111"
+_JOB_2 = "22222222-2222-2222-2222-222222222222"
+
+
+def _pending_summary(job_id: str, job_type: str = "transcribe") -> dict:
+    return {
+        "id": job_id,
+        "session_id": "00000000-0000-0000-0000-0000000000ff",
+        "job_type": job_type,
+        "status": "pending",
+        "created_at": "2026-07-08T00:00:00Z",
+        "updated_at": "2026-07-08T00:00:00Z",
+    }
+
+
+class TestCatchUpOnConnect:
+    async def test_pending_jobs_are_dispatched_after_connect(self, started_sessions_bus: SessionsBus) -> None:
+        # Jobs created while the agent was disconnected are not replayed by SSE; the bus must
+        # reconcile them via the REST listing and dispatch each through the normal job path.
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+        bus._api_client.list_pending_jobs = AsyncMock(return_value=[_pending_summary(_JOB_1), _pending_summary(_JOB_2)])
+        bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)):
+            await bus._connect_and_consume()
+            await _drain_inflight(bus)
+
+        bus._api_client.list_pending_jobs.assert_awaited_once_with(["transcribe"])
+        dispatched = {call.args[0].job_id for call in bus._handle_job_notification.await_args_list}
+        assert dispatched == {UUID(_JOB_1), UUID(_JOB_2)}
+
+    async def test_catch_up_failure_does_not_break_stream(
+        self, started_sessions_bus: SessionsBus, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A failing catch-up listing must be logged and swallowed — the live stream keeps consuming.
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+        bus._api_client.list_pending_jobs = AsyncMock(side_effect=RuntimeError("listing down"))
+        bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)):
+            with caplog.at_level("WARNING"):
+                await bus._connect_and_consume()  # must not raise
+                await _drain_inflight(bus)
+
+        bus._handle_job_notification.assert_not_awaited()
+        assert "catch-up" in caplog.text.lower()
+
+    async def test_malformed_summary_is_skipped(self, started_sessions_bus: SessionsBus) -> None:
+        # One unparseable summary must not stop the others from being dispatched.
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+        bus._api_client.list_pending_jobs = AsyncMock(return_value=[{"garbage": True}, _pending_summary(_JOB_1)])
+        bus._handle_job_notification = AsyncMock()  # type: ignore[method-assign]
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)):
+            await bus._connect_and_consume()
+            await _drain_inflight(bus)
+
+        assert bus._handle_job_notification.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Last-Event-ID resume (same-process reconnect replay from the server ring buffer)
+# ---------------------------------------------------------------------------
+
+
+class TestLastEventIdResume:
+    def test_frame_id_is_tracked(self, started_sessions_bus: SessionsBus) -> None:
+        # Any id-bearing frame advances the resume cursor; a heartbeat isolates the tracking
+        # unit from the job_created path (which spawns a task, covered separately).
+        bus = started_sessions_bus
+        bus._dispatch_sse_event(SimpleNamespace(event="heartbeat", data="", id="12"))
+        assert bus._last_event_id == 12
+
+    def test_non_numeric_id_is_ignored(self, started_sessions_bus: SessionsBus) -> None:
+        bus = started_sessions_bus
+        bus._dispatch_sse_event(SimpleNamespace(event="heartbeat", data="", id="not-a-number"))
+        assert bus._last_event_id is None
+
+    async def test_reconnect_sends_last_event_id(self, started_sessions_bus: SessionsBus) -> None:
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+        bus._api_client.list_pending_jobs = AsyncMock(return_value=[])
+        bus._last_event_id = 7
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)) as mock_sse:
+            await bus._connect_and_consume()
+            await _drain_inflight(bus)
+
+        params = mock_sse.call_args[1]["params"]
+        assert params["last_event_id"] == 7
+
+    async def test_first_connect_omits_last_event_id(self, started_sessions_bus: SessionsBus) -> None:
+        bus = _connectable_bus(started_sessions_bus)
+        bus._api_client.register_agent = AsyncMock(return_value=True)
+        bus._api_client.list_pending_jobs = AsyncMock(return_value=[])
+        assert bus._last_event_id is None
+
+        event_source = MagicMock()
+        event_source.aiter_sse = lambda: _EmptyAsyncIter()
+
+        with patch("blueprint.agents.io.api.eventing.sessions_bus.aconnect_sse", return_value=_mock_sse_context(event_source)) as mock_sse:
+            await bus._connect_and_consume()
+            await _drain_inflight(bus)
+
+        params = mock_sse.call_args[1]["params"]
+        assert "last_event_id" not in params

--- a/tests/unit/agents/services/sessions/test_api_client.py
+++ b/tests/unit/agents/services/sessions/test_api_client.py
@@ -247,3 +247,76 @@ class TestUnregisterAgent:
 
     async def test_swallows_uninitialized_client(self, api_client) -> None:
         await api_client.unregister_agent("agent-1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# list_pending_jobs — reconnect catch-up
+# ---------------------------------------------------------------------------
+
+
+def _summary(job_id: str, job_type: str) -> dict:
+    return {
+        "id": job_id,
+        "session_id": "00000000-0000-0000-0000-0000000000ff",
+        "job_type": job_type,
+        "status": "pending",
+        "created_at": "2026-07-08T00:00:00Z",
+        "updated_at": "2026-07-08T00:00:00Z",
+    }
+
+
+def _list_resp(payload: list[dict]) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestListPendingJobs:
+    async def test_queries_status_pending_once_per_capability(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.get = AsyncMock(side_effect=[_list_resp([_summary("j1", "a")]), _list_resp([_summary("j2", "b")])])
+
+        jobs = await started_api_client.list_pending_jobs(["a", "b"])
+
+        assert mock_http_client.get.await_count == 2
+        # Every call targets /jobs with status=pending and one capability as job_type.
+        seen_types = set()
+        for call in mock_http_client.get.call_args_list:
+            url = call[0][0]
+            params = call[1]["params"]
+            assert url.endswith("/jobs")
+            assert params["status"] == "pending"
+            seen_types.add(params["job_type"])
+        assert seen_types == {"a", "b"}
+        assert {j["id"] for j in jobs} == {"j1", "j2"}
+
+    async def test_single_unfiltered_query_when_no_capabilities(self, started_api_client, mock_http_client) -> None:
+        mock_http_client.get = AsyncMock(return_value=_list_resp([_summary("j1", "a")]))
+
+        jobs = await started_api_client.list_pending_jobs([])
+
+        assert mock_http_client.get.await_count == 1
+        params = mock_http_client.get.call_args[1]["params"]
+        assert params["status"] == "pending"
+        assert "job_type" not in params
+        assert [j["id"] for j in jobs] == ["j1"]
+
+    async def test_merges_and_dedupes_by_id(self, started_api_client, mock_http_client) -> None:
+        # A job returned under two capability queries appears once in the merged result.
+        dup = _summary("dup", "a")
+        mock_http_client.get = AsyncMock(side_effect=[_list_resp([dup]), _list_resp([dup, _summary("j2", "b")])])
+
+        jobs = await started_api_client.list_pending_jobs(["a", "b"])
+
+        ids = [j["id"] for j in jobs]
+        assert sorted(ids) == ["dup", "j2"]
+
+    async def test_calls_raise_for_status(self, started_api_client, mock_http_client) -> None:
+        resp = _list_resp([])
+        mock_http_client.get = AsyncMock(return_value=resp)
+        await started_api_client.list_pending_jobs(["a"])
+        resp.raise_for_status.assert_called_once()
+
+    async def test_raises_when_not_initialized(self, api_client) -> None:
+        with pytest.raises(ValueError, match="not initialized"):
+            await api_client.list_pending_jobs(["a"])


### PR DESCRIPTION
## Summary

- **Root cause:** `SessionsBus` used SSE as a live-only push transport with no reconnect replay. Jobs created during a restart, redeploy, or stream gap stayed `pending` on the server forever and were never delivered. Observed: 9 `analyse.batch` jobs missed after a reconnect (blueprint#57). Distinct follow-on to #45 (which fixed the registration gate but not missed jobs).
- **REST catch-up:** On every (re)connect, after the stream is established (subscribe-then-snapshot ordering), `SessionsBus` calls `GET /jobs?status=pending` for its capabilities and dispatches each pending job through the normal `_handle_job_notification` path. Deduped by the handler's existing `_in_flight`/`_seen` guards. Best-effort — a listing failure is logged and never disturbs the live stream.
- **`Last-Event-ID` resume:** Tracks `sse.id` on each frame and sends `last_event_id` on same-process reconnects so the server ring buffer (500 events) replays missed frames. Omitted on cold start (catch-up covers it).
- **`SessionsApiClient.list_pending_jobs()`:** New method that queries `GET /jobs` once per capability, merges and dedupes results by job id.

## Test plan

- [ ] `TestListPendingJobs` (5 tests) — verifies per-capability queries, unfiltered fallback, dedup by id, `raise_for_status`, uninitialised guard
- [ ] `TestCatchUpOnConnect` (3 tests) — jobs dispatched after connect, listing failure swallowed without disturbing stream, malformed summary skipped
- [ ] `TestLastEventIdResume` (4 tests) — frame id tracked, non-numeric ignored, reconnect sends id, cold start omits id
- [ ] Full suite: 880 tests pass, ruff/black/mypy green
- [ ] `docs/concepts/event-processing.md` updated with reconnect catch-up explanation
- [ ] `CHANGELOG.md` `[Unreleased]` entry added

## Related

- Closes #57
- Follow-on to #45, #44
- Crash-side counterpart (re-pend stranded RUNNING jobs): avs.ai.idac.service-sessions#127 — once that lands, re-pended jobs are redelivered by this catch-up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YugPZ21JYkB7p1E1xph4F