### PR TITLE
fix(#128): inject pipeline_id into SSE job context

### DIFF
--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -300,7 +300,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
 
             try:
                 session_key = await self._require_key_provider().get_session_key(session_id)
-                context = self._build_context(session_id, job_id, session_key)
+                context = self._build_context(session_id, job_id, session_key, pipeline_id=notification.pipeline_id)
                 result = await self._dispatch_cloud_event(event, context)
 
                 if result.status.value == "no_handler_found":
@@ -315,7 +315,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             except httpx.HTTPStatusError as e:
                 if e.response.status_code != 403:
                     raise
-                await self._retry_with_fresh_key(event, session_id, job_id, e)
+                await self._retry_with_fresh_key(event, session_id, job_id, e, pipeline_id=notification.pipeline_id)
 
             except Exception as e:
                 logger.exception("Unexpected error processing job %s: %s", job_id, e)
@@ -330,13 +330,14 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             raise RuntimeError("SessionsApiClient not initialized")
         return self._api_client
 
-    def _build_context(self, session_id: UUID, job_id: UUID, session_key: str) -> dict[str, Any]:
+    def _build_context(self, session_id: UUID, job_id: UUID, session_key: str, pipeline_id: str | None = None) -> dict[str, Any]:
         return {
             "session_id": str(session_id),
             "job_id": str(job_id),
             "session_key": session_key,
             "sessions_api_client": self._require_api_client(),
             "sessions_key_provider": self._require_key_provider(),
+            "pipeline_id": pipeline_id,
         }
 
     async def _cancel_invalid_job(self, session_id: UUID, job_id: UUID, error: InvalidEventError) -> None:
@@ -358,6 +359,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         session_id: UUID,
         job_id: UUID,
         original_error: httpx.HTTPStatusError,
+        pipeline_id: str | None = None,
     ) -> None:
         # A 403 from a handler means the cached session key is stale. Invalidate and retry
         # once through the SAME dispatch seam as the happy path (no separate code path).
@@ -366,7 +368,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         key_provider.invalidate_cache(session_id)
         try:
             session_key = await key_provider.get_session_key(session_id)
-            context = self._build_context(session_id, job_id, session_key)
+            context = self._build_context(session_id, job_id, session_key, pipeline_id=pipeline_id)
             await self._dispatch_cloud_event(event, context)
         except Exception as retry_error:
             logger.error("Retry failed for job %s: %s", job_id, retry_error)

--- a/src/blueprint/agents/models/sessions.py
+++ b/src/blueprint/agents/models/sessions.py
@@ -21,6 +21,7 @@ class JobNotification(BaseModel):
     job_id: UUID
     job_type: str
     created_at: str | None = None
+    pipeline_id: str | None = None
 
     def payload(self) -> dict[str, Any]:
         """The full notification as a JSON-serialisable dict (UUIDs as strings)."""

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -293,6 +293,79 @@ class TestProcessJobNotification:
 
         assert "Unexpected error" in caplog.text
 
+    async def test_pipeline_id_forwarded_to_context(
+        self,
+        started_sessions_bus: SessionsBus,
+    ) -> None:
+        """pipeline_id from the SSE payload is forwarded into the context dict."""
+        notification = JobNotification(
+            session_id=uuid4(),
+            job_id=uuid4(),
+            job_type="classify_documents",
+            pipeline_id="test-pipeline-id",
+        )
+        captured_contexts: list[dict] = []
+
+        async def _capture_dispatch(event, context):
+            captured_contexts.append(context)
+            return ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
+
+        started_sessions_bus._dispatch_cloud_event = _capture_dispatch  # type: ignore[method-assign]
+
+        await started_sessions_bus._process_job_notification(notification)
+
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0]["pipeline_id"] == "test-pipeline-id"
+
+    async def test_pipeline_id_none_when_not_provided(
+        self,
+        started_sessions_bus: SessionsBus,
+        notification: JobNotification,
+    ) -> None:
+        """pipeline_id is None in context when absent from SSE payload (backward compat)."""
+        captured_contexts: list[dict] = []
+
+        async def _capture_dispatch(event, context):
+            captured_contexts.append(context)
+            return ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
+
+        started_sessions_bus._dispatch_cloud_event = _capture_dispatch  # type: ignore[method-assign]
+
+        await started_sessions_bus._process_job_notification(notification)
+
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0]["pipeline_id"] is None
+
+    async def test_pipeline_id_forwarded_on_403_retry(
+        self,
+        started_sessions_bus: SessionsBus,
+    ) -> None:
+        """pipeline_id is preserved in context when _retry_with_fresh_key is invoked."""
+        notification = JobNotification(
+            session_id=uuid4(),
+            job_id=uuid4(),
+            job_type="classify_documents",
+            pipeline_id="pipeline-retry-id",
+        )
+        response_mock = MagicMock()
+        response_mock.status_code = 403
+        http_err = httpx.HTTPStatusError("403", request=MagicMock(), response=response_mock)
+
+        captured_contexts: list[dict] = []
+
+        async def _side_effect(event, context):
+            captured_contexts.append(context)
+            if len(captured_contexts) == 1:
+                raise http_err
+            return ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
+
+        started_sessions_bus._dispatch_cloud_event = _side_effect  # type: ignore[method-assign]
+
+        await started_sessions_bus._process_job_notification(notification)
+
+        assert len(captured_contexts) == 2
+        assert captured_contexts[1]["pipeline_id"] == "pipeline-retry-id"
+
 
 # ---------------------------------------------------------------------------
 # _connect_and_consume — registration gate


### PR DESCRIPTION
## Summary

- Adds `pipeline_id: str | None = None` as an explicit field on `JobNotification` (was previously swallowed by `extra="allow"`)
- Updates `_build_context()` to accept and forward `pipeline_id` in the context dict
- Threads `pipeline_id` through the 403-retry path (`_retry_with_fresh_key`) so it is preserved on key refresh
- `context["pipeline_id"]` is now set for all dispatched jobs, unblocking the classifier's vocabulary fetch from `GET /pipelines/{id}`

## Test Plan

- [ ] `pytest tests/unit/agents/io/api/eventing/test_sessions_bus.py` — 3 new tests: `test_pipeline_id_forwarded_to_context`, `test_pipeline_id_none_when_not_provided`, `test_pipeline_id_forwarded_on_403_retry`
- [ ] End-to-end: run a `classify_documents` job and confirm the vocabulary fetch succeeds without falling back to gBERT-only

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCsksChG19EfhPMU5SP7g6