### PR TITLE
perf(metrics): cache OTel token/latency instruments instead of recreating per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-29
+
+### Fixed
+- **`MetricsRecorder` no longer recreates OTel token/latency instruments on every LLM call** (#64). `record()` called `meter.create_counter`/`create_histogram` on every invocation instead of once; both instruments are now created lazily on first use and cached on the instance. Also documents the previously-undocumented `token_metrics_enabled` config key.
+
 ## [0.6.3] - 2026-07-08
 
 ### Fixed

--- a/docs/reference/configuration-keys.md
+++ b/docs/reference/configuration-keys.md
@@ -99,6 +99,7 @@ OpenTelemetry and tracing settings.
 | `otel_enabled` | `bool` | `false` | Enable OpenTelemetry tracing and metrics export. |
 | `otel_endpoint` | `str` | -- | OTLP collector endpoint URL (e.g., `"http://localhost:4317"`). |
 | `otel_service_name` | `str` | -- | Service name reported to the OTLP collector. Defaults to `app_name` if not set. |
+| `token_metrics_enabled` | `bool` | `true` | Record LLM token usage and response latency to OpenTelemetry. Only takes effect when `otel_enabled` is also `true`. |
 
 ---
 
@@ -139,6 +140,7 @@ suppress_noisy_loggers = true
 otel_enabled = false
 otel_endpoint = "http://localhost:4317"
 otel_service_name = "my_agent_service"
+token_metrics_enabled = true
 
 [default.event_publishing]
 default_pubsub_name = "pubsub"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avs-blueprint-agents"
-version = "0.6.3"
+version = "0.6.4"
 description = "Microservice blueprint for creating agents"
 authors = [
     { name = "Blueprint Team", email = "patrick.maue@bechtle.com" },

--- a/src/blueprint/agent_generator/claude_docs/CLAUDE.md
+++ b/src/blueprint/agent_generator/claude_docs/CLAUDE.md
@@ -82,9 +82,7 @@ class OrderHandler(EventHandlerBase):
     async def can_handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> bool:
         return event.type == "order.placed"
 
-    async def handle_event(
-        self, event: GenericCloudEvent, context: dict[str, Any]
-    ) -> HandlerResult | None:
+    async def handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> HandlerResult | None:
         order = self.extract_payload(event, OrderModel)  # Typed extraction with validation
         result = await self._service.process(order)
         return HandlerResult(event_type="order.processed", data=result)
@@ -172,7 +170,7 @@ class CleanupScheduler(SchedulerBase):
 agent = (
     AgentBuilder(config, runtime_name="analyzer")
     .with_model_from_config("analyzer")
-    .with_system_prompt("system")              # Loads prompts/system.prompt (static, no dynamic inputs)
+    .with_system_prompt("system")  # Loads prompts/system.prompt (static, no dynamic inputs)
     .with_tools([analyze_tool])
     .with_result_type(AnalysisResult)
     .with_metrics()
@@ -199,9 +197,9 @@ result = await self._agent.run(user_prompt=prompt)
 All components access others through `self.registry` (property, NOT a method):
 
 ```python
-self.registry.get_service(MyService)          # By class or "my_service" string
-self.registry.get_agent("my_agent")           # Agent by name
-self.registry.cache_service                   # Cache (if enabled)
+self.registry.get_service(MyService)  # By class or "my_service" string
+self.registry.get_agent("my_agent")  # Agent by name
+self.registry.cache_service  # Cache (if enabled)
 ```
 
 ## Configuration

--- a/src/blueprint/agent_generator/claude_docs/agents/blueprint-builder.md
+++ b/src/blueprint/agent_generator/claude_docs/agents/blueprint-builder.md
@@ -21,11 +21,11 @@ from blueprint.agents.models import GenericCloudEvent, HandlerResult, CloudEvent
 
 **Registry access** (only in `on_startup()`, NEVER in `__init__`):
 ```python
-self.registry.get_service(MyService)       # By class or "my_service" string
-self.registry.get_agent("agent_name")      # Agent by runtime name
-self.registry.get_rest_api(MyApi)          # RestApi
-self.registry.get_scheduler(MyScheduler)   # Scheduler
-self.registry.cache_service                # Cache service (if enabled)
+self.registry.get_service(MyService)  # By class or "my_service" string
+self.registry.get_agent("agent_name")  # Agent by runtime name
+self.registry.get_rest_api(MyApi)  # RestApi
+self.registry.get_scheduler(MyScheduler)  # Scheduler
+self.registry.cache_service  # Cache service (if enabled)
 ```
 
 ## Implementation Process
@@ -62,9 +62,7 @@ class MyHandler(EventHandlerBase):
     async def can_handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> bool:
         return event.type == "my.event.type"
 
-    async def handle_event(
-        self, event: GenericCloudEvent, context: dict[str, Any]
-    ) -> HandlerResult | list[HandlerResult] | None:
+    async def handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> HandlerResult | list[HandlerResult] | None:
         payload = self.extract_payload(event, MyModel)  # Typed extraction with validation
         result = await self._service.process(payload)
         return HandlerResult(event_type="my.result.type", data=result)
@@ -162,7 +160,7 @@ class CleanupScheduler(SchedulerBase):
 my_agent = (
     AgentBuilder(config, runtime_name="my_agent")
     .with_model_from_config("my_agent")
-    .with_system_prompt("system")        # Loads prompts/system.prompt (static, no dynamic inputs)
+    .with_system_prompt("system")  # Loads prompts/system.prompt (static, no dynamic inputs)
     .with_tools([tool_one, tool_two])
     .with_result_type(MyResultModel)
     .with_metrics()
@@ -177,6 +175,7 @@ All models go in `src/models/`:
 ```python
 class OrderModel(BaseModel):
     """Domain model for an order."""
+
     id: str
     customer_id: str
     items: list[OrderItem]

--- a/src/blueprint/agents/agent/metrics.py
+++ b/src/blueprint/agents/agent/metrics.py
@@ -27,6 +27,8 @@ class MetricsRecorder:
         self._config = config
         self._meter = meter
         self._model = model
+        self._token_counter: Any | None = None
+        self._latency_histogram: Any | None = None
 
     def record(
         self,
@@ -92,12 +94,14 @@ class MetricsRecorder:
         # Record to OpenTelemetry if enabled and meter is provided
         if otel_metrics_enabled and self._meter is not None and usage:
             try:
-                # Record token usage as counter
-                token_counter = self._meter.create_counter(
-                    name="llm.tokens.count",
-                    description="Number of tokens processed by the LLM",
-                    unit="tokens",
-                )
+                # Record token usage as counter (instrument created once, then reused)
+                if self._token_counter is None:
+                    self._token_counter = self._meter.create_counter(
+                        name="llm.tokens.count",
+                        description="Number of tokens processed by the LLM",
+                        unit="tokens",
+                    )
+                token_counter = self._token_counter
                 token_counter.add(
                     usage.get("total_tokens", 0),
                     {"model": model_name, "type": "total"},
@@ -117,13 +121,14 @@ class MetricsRecorder:
                         {"model": model_name, "type": "completion"},
                     )
 
-                # Record response latency as histogram
-                latency_histogram = self._meter.create_histogram(
-                    name="llm.response.latency",
-                    description="Distribution of LLM response times",
-                    unit="ms",
-                )
-                latency_histogram.record(duration_ms, {"model": model_name})
+                # Record response latency as histogram (instrument created once, then reused)
+                if self._latency_histogram is None:
+                    self._latency_histogram = self._meter.create_histogram(
+                        name="llm.response.latency",
+                        description="Distribution of LLM response times",
+                        unit="ms",
+                    )
+                self._latency_histogram.record(duration_ms, {"model": model_name})
 
                 logger.debug("OpenTelemetry metrics recorded successfully")
             except Exception as e:

--- a/src/blueprint/agents/io/api/actuators/health/README.md
+++ b/src/blueprint/agents/io/api/actuators/health/README.md
@@ -44,6 +44,7 @@ Abstract base class that all health checkers must inherit from.
 from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 
+
 class CustomHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         """Perform health check logic."""
@@ -51,8 +52,7 @@ class CustomHealthChecker(HealthCheckerBase):
             # Check component status
             is_healthy = await check_service()
             return ComponentHealth(
-                status="UP" if is_healthy else "DOWN",
-                message="Service is operational" if is_healthy else "Service unavailable"
+                status="UP" if is_healthy else "DOWN", message="Service is operational" if is_healthy else "Service unavailable"
             )
         except Exception as e:
             return ComponentHealth(status="DOWN", message=str(e))
@@ -165,10 +165,7 @@ from blueprint.agents.services.health.cache import HealthCheckCache
 cache = HealthCheckCache(check_interval_seconds=30)
 
 # Set health check providers
-providers = {
-    "dapr": DaprPubSubHealthChecker(config),
-    "ai_provider": VLLMProviderHealthChecker(config)
-}
+providers = {"dapr": DaprPubSubHealthChecker(config), "ai_provider": VLLMProviderHealthChecker(config)}
 cache.set_health_check_provider(providers)
 
 # Start background scheduler
@@ -190,10 +187,12 @@ from blueprint.agents import AppBuilder, Config
 from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 
+
 class DatabaseHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         # Check database connection
         return ComponentHealth(status="UP", message="DB OK")
+
 
 config = Config(...)
 builder = AppBuilder(config)
@@ -227,6 +226,7 @@ from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 import httpx
 
+
 class ExternalAPIHealthChecker(HealthCheckerBase):
     def __init__(self, api_url: str):
         self.api_url = api_url
@@ -236,15 +236,9 @@ class ExternalAPIHealthChecker(HealthCheckerBase):
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(f"{self.api_url}/health")
                 response.raise_for_status()
-                return ComponentHealth(
-                    status="UP",
-                    message=f"API reachable at {self.api_url}"
-                )
+                return ComponentHealth(status="UP", message=f"API reachable at {self.api_url}")
         except Exception as e:
-            return ComponentHealth(
-                status="DOWN",
-                message=f"API unreachable: {e}"
-            )
+            return ComponentHealth(status="DOWN", message=f"API unreachable: {e}")
 ```
 
 ## Integration with AppBuilder
@@ -279,14 +273,11 @@ from blueprint.agents.models.api import ComponentHealth
 
 health = ComponentHealth(
     status="UP",  # or "DOWN"
-    message="Service is operational"
+    message="Service is operational",
 )
 
 # Response format
-{
-    "status": "UP",
-    "message": "Service is operational"
-}
+{"status": "UP", "message": "Service is operational"}
 ```
 
 ## Configuration
@@ -319,6 +310,7 @@ from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 from pathlib import Path
 
+
 # Define custom health checker
 class RedisHealthChecker(HealthCheckerBase):
     def __init__(self, redis_url: str):
@@ -327,6 +319,7 @@ class RedisHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         try:
             import redis.asyncio as redis
+
             r = await redis.from_url(self.redis_url, socket_connect_timeout=2)
             await r.ping()
             await r.close()
@@ -334,11 +327,9 @@ class RedisHealthChecker(HealthCheckerBase):
         except Exception as e:
             return ComponentHealth(status="DOWN", message=f"Redis error: {e}")
 
+
 # Setup
-config = Config(
-    settings_files=["settings.toml"],
-    root_path=Path(__file__).parent
-)
+config = Config(settings_files=["settings.toml"], root_path=Path(__file__).parent)
 
 builder = AppBuilder(config)
 
@@ -362,9 +353,11 @@ import pytest
 from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 
+
 class TestHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         return ComponentHealth(status="UP", message="Test OK")
+
 
 @pytest.mark.asyncio
 async def test_health_checker():

--- a/tests/unit/agents/agent/test_metrics_recorder.py
+++ b/tests/unit/agents/agent/test_metrics_recorder.py
@@ -86,6 +86,19 @@ class TestRecord:
         recorder = MetricsRecorder(otel_on_config, meter=None)
         recorder.record(_result(_usage()), 100.0, "gpt-4o")  # must not raise
 
+    def test_instruments_created_once_and_reused_across_calls(self, otel_on_config: MagicMock) -> None:
+        meter = MagicMock()
+        recorder = MetricsRecorder(otel_on_config, meter=meter)
+
+        recorder.record(_result(_usage()), 100.0, "gpt-4o")
+        recorder.record(_result(_usage()), 150.0, "gpt-4o")
+        recorder.record(_result(_usage()), 200.0, "gpt-4o")
+
+        meter.create_counter.assert_called_once()
+        meter.create_histogram.assert_called_once()
+        assert meter.create_counter.return_value.add.call_count == 9  # 3 calls x (total, prompt, completion)
+        assert meter.create_histogram.return_value.record.call_count == 3
+
     def test_config_exception_suppressed(self) -> None:
         config = MagicMock(spec=Config)
         config.get_observability_config.side_effect = RuntimeError("config unavailable")


### PR DESCRIPTION
## Summary
- `MetricsRecorder.record()` called `meter.create_counter(...)` / `meter.create_histogram(...)` on every LLM call instead of once, adding avoidable per-request CPU overhead and repeated instrument registration in the OTel SDK.
- Both instruments are now created lazily on first use and cached on the instance (`self._token_counter` / `self._latency_histogram`), then reused across subsequent `record()` calls.
- Creation stays lazy (first *enabled* call) rather than moving to `__init__` unconditionally, since a meter can be passed in even when `otel_enabled`/`token_metrics_enabled` are `False` — eager creation would have broken the existing `test_no_otel_when_disabled` test.
- Documented the previously-undocumented `token_metrics_enabled` config key in `docs/reference/configuration-keys.md`.

Fixes #64 (sub-issue of #32).

## Test plan
- [x] `uv run pytest tests/unit/agents/agent/test_metrics_recorder.py tests/unit/agents/agent/test_metrics_extractor.py -v` — 16 passed, including new `test_instruments_created_once_and_reused_across_calls`
- [x] `ruff check` / `black --check` / `mypy` clean on changed files