### PR TITLE
chore: fix ruff format drift in doc code blocks

### DIFF
--- a/src/blueprint/agent_generator/claude_docs/CLAUDE.md
+++ b/src/blueprint/agent_generator/claude_docs/CLAUDE.md
@@ -82,9 +82,7 @@ class OrderHandler(EventHandlerBase):
     async def can_handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> bool:
         return event.type == "order.placed"
 
-    async def handle_event(
-        self, event: GenericCloudEvent, context: dict[str, Any]
-    ) -> HandlerResult | None:
+    async def handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> HandlerResult | None:
         order = self.extract_payload(event, OrderModel)  # Typed extraction with validation
         result = await self._service.process(order)
         return HandlerResult(event_type="order.processed", data=result)
@@ -172,7 +170,7 @@ class CleanupScheduler(SchedulerBase):
 agent = (
     AgentBuilder(config, runtime_name="analyzer")
     .with_model_from_config("analyzer")
-    .with_system_prompt("system")              # Loads prompts/system.prompt (static, no dynamic inputs)
+    .with_system_prompt("system")  # Loads prompts/system.prompt (static, no dynamic inputs)
     .with_tools([analyze_tool])
     .with_result_type(AnalysisResult)
     .with_metrics()
@@ -199,9 +197,9 @@ result = await self._agent.run(user_prompt=prompt)
 All components access others through `self.registry` (property, NOT a method):
 
 ```python
-self.registry.get_service(MyService)          # By class or "my_service" string
-self.registry.get_agent("my_agent")           # Agent by name
-self.registry.cache_service                   # Cache (if enabled)
+self.registry.get_service(MyService)  # By class or "my_service" string
+self.registry.get_agent("my_agent")  # Agent by name
+self.registry.cache_service  # Cache (if enabled)
 ```
 
 ## Configuration

--- a/src/blueprint/agent_generator/claude_docs/agents/blueprint-builder.md
+++ b/src/blueprint/agent_generator/claude_docs/agents/blueprint-builder.md
@@ -21,11 +21,11 @@ from blueprint.agents.models import GenericCloudEvent, HandlerResult, CloudEvent
 
 **Registry access** (only in `on_startup()`, NEVER in `__init__`):
 ```python
-self.registry.get_service(MyService)       # By class or "my_service" string
-self.registry.get_agent("agent_name")      # Agent by runtime name
-self.registry.get_rest_api(MyApi)          # RestApi
-self.registry.get_scheduler(MyScheduler)   # Scheduler
-self.registry.cache_service                # Cache service (if enabled)
+self.registry.get_service(MyService)  # By class or "my_service" string
+self.registry.get_agent("agent_name")  # Agent by runtime name
+self.registry.get_rest_api(MyApi)  # RestApi
+self.registry.get_scheduler(MyScheduler)  # Scheduler
+self.registry.cache_service  # Cache service (if enabled)
 ```
 
 ## Implementation Process
@@ -62,9 +62,7 @@ class MyHandler(EventHandlerBase):
     async def can_handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> bool:
         return event.type == "my.event.type"
 
-    async def handle_event(
-        self, event: GenericCloudEvent, context: dict[str, Any]
-    ) -> HandlerResult | list[HandlerResult] | None:
+    async def handle_event(self, event: GenericCloudEvent, context: dict[str, Any]) -> HandlerResult | list[HandlerResult] | None:
         payload = self.extract_payload(event, MyModel)  # Typed extraction with validation
         result = await self._service.process(payload)
         return HandlerResult(event_type="my.result.type", data=result)
@@ -162,7 +160,7 @@ class CleanupScheduler(SchedulerBase):
 my_agent = (
     AgentBuilder(config, runtime_name="my_agent")
     .with_model_from_config("my_agent")
-    .with_system_prompt("system")        # Loads prompts/system.prompt (static, no dynamic inputs)
+    .with_system_prompt("system")  # Loads prompts/system.prompt (static, no dynamic inputs)
     .with_tools([tool_one, tool_two])
     .with_result_type(MyResultModel)
     .with_metrics()
@@ -177,6 +175,7 @@ All models go in `src/models/`:
 ```python
 class OrderModel(BaseModel):
     """Domain model for an order."""
+
     id: str
     customer_id: str
     items: list[OrderItem]

--- a/src/blueprint/agents/io/api/actuators/health/README.md
+++ b/src/blueprint/agents/io/api/actuators/health/README.md
@@ -44,6 +44,7 @@ Abstract base class that all health checkers must inherit from.
 from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 
+
 class CustomHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         """Perform health check logic."""
@@ -51,8 +52,7 @@ class CustomHealthChecker(HealthCheckerBase):
             # Check component status
             is_healthy = await check_service()
             return ComponentHealth(
-                status="UP" if is_healthy else "DOWN",
-                message="Service is operational" if is_healthy else "Service unavailable"
+                status="UP" if is_healthy else "DOWN", message="Service is operational" if is_healthy else "Service unavailable"
             )
         except Exception as e:
             return ComponentHealth(status="DOWN", message=str(e))
@@ -165,10 +165,7 @@ from blueprint.agents.services.health.cache import HealthCheckCache
 cache = HealthCheckCache(check_interval_seconds=30)
 
 # Set health check providers
-providers = {
-    "dapr": DaprPubSubHealthChecker(config),
-    "ai_provider": VLLMProviderHealthChecker(config)
-}
+providers = {"dapr": DaprPubSubHealthChecker(config), "ai_provider": VLLMProviderHealthChecker(config)}
 cache.set_health_check_provider(providers)
 
 # Start background scheduler
@@ -190,10 +187,12 @@ from blueprint.agents import AppBuilder, Config
 from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 
+
 class DatabaseHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         # Check database connection
         return ComponentHealth(status="UP", message="DB OK")
+
 
 config = Config(...)
 builder = AppBuilder(config)
@@ -227,6 +226,7 @@ from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 import httpx
 
+
 class ExternalAPIHealthChecker(HealthCheckerBase):
     def __init__(self, api_url: str):
         self.api_url = api_url
@@ -236,15 +236,9 @@ class ExternalAPIHealthChecker(HealthCheckerBase):
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(f"{self.api_url}/health")
                 response.raise_for_status()
-                return ComponentHealth(
-                    status="UP",
-                    message=f"API reachable at {self.api_url}"
-                )
+                return ComponentHealth(status="UP", message=f"API reachable at {self.api_url}")
         except Exception as e:
-            return ComponentHealth(
-                status="DOWN",
-                message=f"API unreachable: {e}"
-            )
+            return ComponentHealth(status="DOWN", message=f"API unreachable: {e}")
 ```
 
 ## Integration with AppBuilder
@@ -279,14 +273,11 @@ from blueprint.agents.models.api import ComponentHealth
 
 health = ComponentHealth(
     status="UP",  # or "DOWN"
-    message="Service is operational"
+    message="Service is operational",
 )
 
 # Response format
-{
-    "status": "UP",
-    "message": "Service is operational"
-}
+{"status": "UP", "message": "Service is operational"}
 ```
 
 ## Configuration
@@ -319,6 +310,7 @@ from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 from pathlib import Path
 
+
 # Define custom health checker
 class RedisHealthChecker(HealthCheckerBase):
     def __init__(self, redis_url: str):
@@ -327,6 +319,7 @@ class RedisHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         try:
             import redis.asyncio as redis
+
             r = await redis.from_url(self.redis_url, socket_connect_timeout=2)
             await r.ping()
             await r.close()
@@ -334,11 +327,9 @@ class RedisHealthChecker(HealthCheckerBase):
         except Exception as e:
             return ComponentHealth(status="DOWN", message=f"Redis error: {e}")
 
+
 # Setup
-config = Config(
-    settings_files=["settings.toml"],
-    root_path=Path(__file__).parent
-)
+config = Config(settings_files=["settings.toml"], root_path=Path(__file__).parent)
 
 builder = AppBuilder(config)
 
@@ -362,9 +353,11 @@ import pytest
 from blueprint.agents.services.health import HealthCheckerBase
 from blueprint.agents.models.api import ComponentHealth
 
+
 class TestHealthChecker(HealthCheckerBase):
     async def health_check(self) -> ComponentHealth:
         return ComponentHealth(status="UP", message="Test OK")
+
 
 @pytest.mark.asyncio
 async def test_health_checker():


### PR DESCRIPTION
## Summary
`ruff format --check src tests` currently fails on `develop` itself (independent of any feature branch) — a newer ruff release now reformats Python code blocks embedded in Markdown files, and 3 docs predate that:
- `src/blueprint/agent_generator/claude_docs/CLAUDE.md`
- `src/blueprint/agent_generator/claude_docs/agents/blueprint-builder.md`
- `src/blueprint/agents/io/api/actuators/health/README.md`

Ran `ruff format src tests` — purely cosmetic (line-wrap/whitespace inside fenced code blocks), no content change. This was discovered because it's currently failing CI on three unrelated open PRs (#68, #69, #70), all of which fail the same pre-existing check regardless of their own diff.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean (228 files formatted)
- [x] `mypy src` — clean