### PR TITLE
docs(spec): job-scoped SessionKeyProvider source

### DIFF
--- a/docs/specs/2026-08-24-job-scoped-session-key-source.md
+++ b/docs/specs/2026-08-24-job-scoped-session-key-source.md
@@ -1,7 +1,8 @@
-# Spec: Add a job-scoped `"job"` source to `SessionKeyProvider`
+# Spec: Read the session key directly off the job dispatch notification
 
 **Issue:** bechtleav360/AVS.AI.Blueprint.AgenticService#76
-**Depends on (server contract):** bechtleav360/avs.ai.idac.service-sessions#194
+**Companion (server contract):** bechtleav360/avs.ai.idac.service-sessions#194
+**Status:** spec r2 — supersedes r1 (r1's server-side dependency was DENY'd; see below)
 
 ## Goal
 
@@ -20,113 +21,131 @@ ValueError: Environment variable SESSION_KEY not set
   File "blueprint/agents/services/sessions/key_provider.py", line 138, in _get_from_env
 ```
 
-`env` (the default) and `config` both assume one static key shared by every session — wrong by
-construction once a consumer's sessions service issues (and validates) a distinct key per
-session, which `avs.ai.idac.service-sessions` does whenever its encryption policy is at its
-default (`storage.encryption_enabled=true`). `vault` raises `NotImplementedError`. `remote`
-(`_get_from_remote`, fetch by `session_id`) has no matching server endpoint on
-`avs.ai.idac.service-sessions` today, and building one that returns *any* session's key by id
-alone would sit awkwardly next to that service's own "zero-knowledge encrypted sessions" framing.
+## r1 → r2: the server-side dependency changed shape
 
-## Root cause / gap
+r1 proposed a `"job"` source that fetched the key via a new server endpoint
+(`GET .../jobs/{job_id}/session-key`). Review on the server-side companion spec
+(bechtleav360/avs.ai.idac.service-sessions#196) found that endpoint isn't implementable: the
+server never persists the raw session key (only its SHA-256 hash, for comparison), so there is no
+later moment for a fetch to return it from. The corrected server-side design instead attaches
+`session_key` directly to the `job_created` SSE payload, at the one point the server actually has
+the key (synchronously, inside the request that creates the job). Full reasoning in #196's spec.
+
+This *simplifies* this repo's side of the fix: no new HTTP call, no new endpoint dependency, no
+new failure mode from a network round-trip mid-job. The key is already inbound on the same
+connection that delivered the job notification.
+
+## Root cause / gap (unchanged from r1)
 
 The class docstring already gestures at the right shape — "Per-session keys passed via context
 (Phase 3)" — but it was never implemented: `get_session_key`'s branch list is only
 `env`/`config`/`vault`/`remote`, and the docstring's `Options:` line (`env, vault, context`) has
 also drifted from the actual code (missing `config` and `remote`, listing unimplemented
-`context`). Sessions-side, nothing currently carries a session key anywhere the agent could read
-it — not on the SSE notification, not anywhere else.
+`context`).
 
 ## Design
 
-**New source: `"job"`.** Fetches the key from the job-scoped endpoint specified in
-bechtleav360/avs.ai.idac.service-sessions#194 (`GET /internal/jobs/{job_id}/session-key`,
-`X-Api-Key` auth) rather than adding a field to the broadcast/notification payload — see that
-spec's "Why not put the key on the existing broadcast" section for the reasoning (this framework
-is one of potentially several consumers of that service; the fetch-by-job-id shape is the
-contract being proposed there, not something this repo should quietly assume by adding fields to
-its own `JobNotification` model).
+**`JobNotification` gains an optional field**, populated only when the sessions service sends one
+(backward compatible — older/other sessions-service versions simply omit it):
 
 ```python
-# key_provider.py
-async def get_session_key(self, session_id: UUID | None = None, job_id: UUID | None = None) -> str:
+# models/sessions.py
+class JobNotification(BaseModel):
     ...
-    if self._source == "job":
-        session_key = await self._get_from_job(job_id)
-    ...
-
-async def _get_from_job(self, job_id: UUID | None) -> str:
-    if not job_id:
-        raise ValueError("job_id required for 'job' source")
-    if not self._remote_url:
-        raise ValueError("sessions_service.session_key_remote_url not configured")
-    url = f"{self._remote_url}/internal/jobs/{job_id}/session-key"
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(url, headers={"X-Api-Key": self._api_key})
-        response.raise_for_status()
-        return response.json()["session_key"]
+    session_key: str | None = None
 ```
 
-- `job_id` is a new optional parameter on `get_session_key`, threaded through from the three call
-  sites in `sessions_bus.py` (lines 377, 421, 445) — all three already have `job_id` in scope
-  from the notification they're handling.
-- **Caching is unchanged.** The existing cache keys by `session_id`, not by source — a `"job"`
-  fetch populates the same `TTLCache` under `str(session_id)`, so a second job in the same
-  session hits the cache without needing its `job_id` at all. Only the cache-miss path needs
-  `job_id`.
-- Reuses the existing `session_key_remote_url` / `api_key` config fields (already present for
-  `remote`) rather than adding new ones — same shape, different path suffix.
+`model_config = ConfigDict(extra="allow")` already meant an unrecognised `session_key` key would
+have passed through silently before; declaring it explicitly makes it a real, typed, documented
+field instead of relying on that fallback.
+
+**New source: `"context"`** (reclaiming the docstring's original Phase-3 name, since the mechanism
+now genuinely matches what that name always implied — the key travels with the request/event
+context, not a side-channel fetch):
+
+```python
+async def get_session_key(
+    self, session_id: UUID | None = None, notification_key: str | None = None
+) -> str:
+    cache_key = str(session_id) if session_id else "default"
+    if self._cache is not None and cache_key in self._cache:
+        return self._cache[cache_key]
+
+    if self._source == "context":
+        if not notification_key:
+            raise ValueError("session_key not present on notification; source='context' requires it")
+        session_key = notification_key
+    elif self._source == "env":
+        ...
+    # ...existing branches unchanged...
+
+    if self._cache is not None:
+        self._cache[cache_key] = session_key
+    return session_key
+```
+
+- `notification_key` is a new optional parameter, threaded from the three call sites in
+  `sessions_bus.py` (lines 377, 421, 445) as `notification_key=notification.session_key` — all
+  three already have the `notification` object in scope.
+- **Caching is unchanged in shape**, still keyed by `session_id` — a `"context"` resolution
+  populates the same `TTLCache`, so if the *same* session's key arrives again on a later job
+  notification (or the cache is still warm from an earlier one), redundant work is avoided the
+  same way the existing sources already benefit from the cache.
 - Fix the docstring's `Options:` line to list the actual implemented sources
-  (`env, config, vault, remote, job`) and drop the unimplemented `context` mention, or rename
-  `"job"` to `"context"` if the reviewer prefers keeping that name from the original design intent
-  — naming is not load-bearing, the fetch-by-job-id mechanism is.
+  (`env, config, vault, remote, context`).
+- `remote`/`_get_from_remote` stays as-is, dead-ish code for now (no server implements it), not
+  removed — out of scope to touch it here.
 
 ## In scope
 
-1. `job_id: UUID | None = None` parameter on `SessionKeyProvider.get_session_key`.
-2. New `_get_from_job` method + `"job"` branch.
-3. Update the three `sessions_bus.py` call sites to pass `job_id=notification.job_id`.
-4. Correct the class docstring's `Options:` line.
-5. Unit tests: cache hit skips the fetch entirely (job_id not required in that path), `"job"`
-   source with no `job_id` raises `ValueError`, successful fetch caches under `session_id`,
-   non-2xx response propagates as `httpx.HTTPStatusError` (consistent with `_get_from_remote`'s
-   existing behavior — not swallowed).
+1. `session_key: str | None = None` field on `JobNotification`.
+2. `notification_key: str | None = None` parameter on `SessionKeyProvider.get_session_key`.
+3. New `"context"` branch (no new async method needed — it's a direct assignment, not a fetch).
+4. Update the three `sessions_bus.py` call sites to pass `notification_key=notification.session_key`.
+5. Correct the class docstring's `Options:` line.
+6. Unit tests: `"context"` source with `notification_key` present populates and caches correctly;
+   `"context"` with `notification_key=None` raises `ValueError` before doing anything else; a
+   second call for the same `session_id` hits the cache regardless of whether a fresh
+   `notification_key` was supplied.
 
 ## Out of scope
 
-- The server-side endpoint itself — bechtleav360/avs.ai.idac.service-sessions#194, this repo only
-  consumes it.
+- The server-side change itself — bechtleav360/avs.ai.idac.service-sessions#196, this repo only
+  consumes its output.
 - `vault` implementation (unrelated pre-existing gap).
-- Any change to `JobNotification`'s fields — deliberately not adding `session_key` there, see
-  Design above.
-- Retry/backoff policy for the fetch — matches `_get_from_remote`'s current (no-retry) behavior;
-  a separate concern if it needs hardening.
+- `remote`/`_get_from_remote` — left in place, unused by any current consumer, not this spec's
+  concern to remove or fix.
+- Any handling for the orphan-reaper re-announce case where no key is attached server-side
+  (service-sessions#196's Open Questions) — this repo's cache-based mitigation for that case is
+  already implicit in the caching behavior above (a repend within the TTL window resolves from
+  cache without needing a fresh `notification_key`); nothing further to build here.
 
 ## Acceptance criteria
 
-- **AC-1** `get_session_key(session_id, job_id=X)` with `source="job"` and a cache miss calls
-  `GET {remote_url}/internal/jobs/{X}/session-key` and returns the key from the response.
-- **AC-2** A subsequent call for the same `session_id` (different `job_id`, or none) hits the
-  cache and makes no HTTP call.
-- **AC-3** `source="job"` with no `job_id` raises `ValueError` before attempting any network call.
+- **AC-1** `get_session_key(session_id, notification_key=X)` with `source="context"` and a cache
+  miss returns `X` and caches it under `session_id` — no network call.
+- **AC-2** A subsequent call for the same `session_id` (with or without a fresh
+  `notification_key`) hits the cache.
+- **AC-3** `source="context"` with `notification_key=None` raises `ValueError` immediately.
 - **AC-4** `env`/`config`/`vault`/`remote` sources are unaffected — no behavior change for
   existing consumers (VerA's deployment, per `agents-document-analyser`'s CLAUDE.md, stays on
   whatever it currently uses).
 - **AC-5** Docstring's `Options:` line matches the actual branch list in code.
+- **AC-6** `JobNotification.session_key` defaults to `None` and does not break parsing of
+  notifications from a sessions-service version that doesn't send it.
 
 ## Constraints
 
-- Backward compatible: `job_id` is optional and only required when `source == "job"`; every other
-  source's call signature and behavior is unchanged.
-- No new dependency — `httpx` is already used by `_get_from_remote`.
+- Backward compatible: `notification_key` is optional and only required when
+  `source == "context"`; every other source's call signature and behavior is unchanged.
+- No new dependency (this version needs no `httpx` call at all, unlike r1).
 
 ## Open questions
 
-- Confirm the endpoint path/prefix (`/internal/...` vs. something else) once
-  bechtleav360/avs.ai.idac.service-sessions#194's spec is approved — this repo's `_get_from_job`
-  should match whatever that spec lands on.
+None blocking — the server contract is settled by service-sessions#196's r2.
 
 ## Related issues
 
 - bechtleav360/avs.ai.project.pida#385 — where this was found live.
-- bechtleav360/avs.ai.idac.service-sessions#194 — the server-side endpoint this depends on.
+- bechtleav360/avs.ai.idac.service-sessions#196 — the server-side change this depends on (r2, the
+  design that made this simpler).

--- a/docs/specs/2026-08-24-job-scoped-session-key-source.md
+++ b/docs/specs/2026-08-24-job-scoped-session-key-source.md
@@ -1,8 +1,8 @@
-# Spec: Read the session key directly off the job dispatch notification
+# Spec: Add a job-scoped `"job"` source to `SessionKeyProvider`
 
 **Issue:** bechtleav360/AVS.AI.Blueprint.AgenticService#76
-**Companion (server contract):** bechtleav360/avs.ai.idac.service-sessions#194
-**Status:** spec r2 — supersedes r1 (r1's server-side dependency was DENY'd; see below)
+**Companion (server contract):** bechtleav360/avs.ai.idac.service-sessions#196
+**Status:** spec r3 — supersedes r2 (r2's server-side dependency was DENY'd; see below)
 
 ## Goal
 
@@ -21,21 +21,22 @@ ValueError: Environment variable SESSION_KEY not set
   File "blueprint/agents/services/sessions/key_provider.py", line 138, in _get_from_env
 ```
 
-## r1 → r2: the server-side dependency changed shape
+## r2 → r3: the server-side dependency changed shape again
 
-r1 proposed a `"job"` source that fetched the key via a new server endpoint
-(`GET .../jobs/{job_id}/session-key`). Review on the server-side companion spec
-(bechtleav360/avs.ai.idac.service-sessions#196) found that endpoint isn't implementable: the
-server never persists the raw session key (only its SHA-256 hash, for comparison), so there is no
-later moment for a fetch to return it from. The corrected server-side design instead attaches
-`session_key` directly to the `job_created` SSE payload, at the one point the server actually has
-the key (synchronously, inside the request that creates the job). Full reasoning in #196's spec.
+r2 proposed reading `session_key` directly off the `job_created` SSE notification, because the
+server-side companion spec's r2 (service-sessions#196) attached it there. That server-side r2 was
+DENY'd: the agent SSE channel's replay buffer turned out to have no per-recipient access control
+(a process-wide, capability-filtered-only 500-entry ring buffer, replayable by any `X-Api-Key`
+holder via auto-registration), so putting a raw session key in that payload would have made every
+dispatched key bulk-harvestable. The server-side r3 instead keeps `job_created` **completely
+unchanged** and introduces a one-time, short-lived (15 min TTL), single-use fetch:
+`GET /internal/jobs/{job_id}/session-key`, backed by storage that never touches the broadcast
+path. Full reasoning in service-sessions#196's r3.
 
-This *simplifies* this repo's side of the fix: no new HTTP call, no new endpoint dependency, no
-new failure mode from a network round-trip mid-job. The key is already inbound on the same
-connection that delivered the job notification.
+This reverts this repo's side back to a fetch-based source (closer to r1's shape, not r2's) — but
+against a real, correctly-scoped endpoint this time, not r1's endpoint whose premise didn't hold.
 
-## Root cause / gap (unchanged from r1)
+## Root cause / gap (unchanged since r1)
 
 The class docstring already gestures at the right shape — "Per-session keys passed via context
 (Phase 3)" — but it was never implemented: `get_session_key`'s branch list is only
@@ -45,36 +46,20 @@ also drifted from the actual code (missing `config` and `remote`, listing unimpl
 
 ## Design
 
-**`JobNotification` gains an optional field**, populated only when the sessions service sends one
-(backward compatible — older/other sessions-service versions simply omit it):
-
-```python
-# models/sessions.py
-class JobNotification(BaseModel):
-    ...
-    session_key: str | None = None
-```
-
-`model_config = ConfigDict(extra="allow")` already meant an unrecognised `session_key` key would
-have passed through silently before; declaring it explicitly makes it a real, typed, documented
-field instead of relying on that fallback.
-
-**New source: `"context"`** (reclaiming the docstring's original Phase-3 name, since the mechanism
-now genuinely matches what that name always implied — the key travels with the request/event
-context, not a side-channel fetch):
+**New source: `"job"`.** Fetches the key once via
+`GET {remote_url}/internal/jobs/{job_id}/session-key` (`X-Api-Key` auth), per
+service-sessions#196's r3 contract:
 
 ```python
 async def get_session_key(
-    self, session_id: UUID | None = None, notification_key: str | None = None
+    self, session_id: UUID | None = None, job_id: UUID | None = None
 ) -> str:
     cache_key = str(session_id) if session_id else "default"
     if self._cache is not None and cache_key in self._cache:
         return self._cache[cache_key]
 
-    if self._source == "context":
-        if not notification_key:
-            raise ValueError("session_key not present on notification; source='context' requires it")
-        session_key = notification_key
+    if self._source == "job":
+        session_key = await self._get_from_job(job_id)
     elif self._source == "env":
         ...
     # ...existing branches unchanged...
@@ -82,70 +67,85 @@ async def get_session_key(
     if self._cache is not None:
         self._cache[cache_key] = session_key
     return session_key
+
+async def _get_from_job(self, job_id: UUID | None) -> str:
+    if not job_id:
+        raise ValueError("job_id required for 'job' source")
+    if not self._remote_url:
+        raise ValueError("sessions_service.session_key_remote_url not configured")
+    url = f"{self._remote_url}/internal/jobs/{job_id}/session-key"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(url, headers={"X-Api-Key": self._api_key})
+        response.raise_for_status()  # 404 (already claimed / expired / unknown) raises here
+        return response.json()["session_key"]
 ```
 
-- `notification_key` is a new optional parameter, threaded from the three call sites in
-  `sessions_bus.py` (lines 377, 421, 445) as `notification_key=notification.session_key` — all
-  three already have the `notification` object in scope.
-- **Caching is unchanged in shape**, still keyed by `session_id` — a `"context"` resolution
-  populates the same `TTLCache`, so if the *same* session's key arrives again on a later job
-  notification (or the cache is still warm from an earlier one), redundant work is avoided the
-  same way the existing sources already benefit from the cache.
+- `job_id` is a new optional parameter on `get_session_key`, threaded from the three call sites in
+  `sessions_bus.py` (lines 377, 421, 445) — all three already have `job_id` in scope from the
+  notification they're handling.
+- **The fetch is single-use server-side** (service-sessions#196 AC-2) — a second call for the
+  same `job_id` 404s. This makes the client-side cache load-bearing in a way it wasn't for
+  `env`/`config`/`remote`: once fetched, the cached value is the *only* copy this process can
+  still obtain for that session. If the cache entry is evicted (TTL, default 3600s) before every
+  job needing that key has been processed, there is no recovery — a retry would hit the
+  already-consumed endpoint and 404. See Constraints.
+- Reuses the existing `session_key_remote_url` / `api_key` config fields (already present for
+  `remote`) rather than adding new ones.
 - Fix the docstring's `Options:` line to list the actual implemented sources
-  (`env, config, vault, remote, context`).
-- `remote`/`_get_from_remote` stays as-is, dead-ish code for now (no server implements it), not
-  removed — out of scope to touch it here.
+  (`env, config, vault, remote, job`) and drop the unimplemented `context` mention.
 
 ## In scope
 
-1. `session_key: str | None = None` field on `JobNotification`.
-2. `notification_key: str | None = None` parameter on `SessionKeyProvider.get_session_key`.
-3. New `"context"` branch (no new async method needed — it's a direct assignment, not a fetch).
-4. Update the three `sessions_bus.py` call sites to pass `notification_key=notification.session_key`.
-5. Correct the class docstring's `Options:` line.
-6. Unit tests: `"context"` source with `notification_key` present populates and caches correctly;
-   `"context"` with `notification_key=None` raises `ValueError` before doing anything else; a
-   second call for the same `session_id` hits the cache regardless of whether a fresh
-   `notification_key` was supplied.
+1. `job_id: UUID | None = None` parameter on `SessionKeyProvider.get_session_key`.
+2. New `_get_from_job` method + `"job"` branch.
+3. Update the three `sessions_bus.py` call sites to pass `job_id=notification.job_id`.
+4. Correct the class docstring's `Options:` line.
+5. Unit tests: cache hit skips the fetch entirely; `"job"` source with no `job_id` raises
+   `ValueError` before any network call; successful fetch caches under `session_id`; a 404
+   response (already-claimed/expired/unknown) propagates as `httpx.HTTPStatusError` rather than
+   being swallowed or silently retried (a silent retry would always 404 given single-use — a
+   test should assert there is no retry loop here).
 
 ## Out of scope
 
-- The server-side change itself — bechtleav360/avs.ai.idac.service-sessions#196, this repo only
-  consumes its output.
+- The server-side endpoint and its storage — service-sessions#196, this repo only consumes it.
 - `vault` implementation (unrelated pre-existing gap).
-- `remote`/`_get_from_remote` — left in place, unused by any current consumer, not this spec's
-  concern to remove or fix.
-- Any handling for the orphan-reaper re-announce case where no key is attached server-side
-  (service-sessions#196's Open Questions) — this repo's cache-based mitigation for that case is
-  already implicit in the caching behavior above (a repend within the TTL window resolves from
-  cache without needing a fresh `notification_key`); nothing further to build here.
+- `remote`/`_get_from_remote` — left in place, unused by any current consumer.
+- Cache-eviction-vs-single-use hardening (e.g. pinning the TTL for `"job"`-sourced entries higher
+  than the default, or re-deriving from a fresh notification if one arrives) — flagged in
+  Constraints as a real gap, not solved here; the default cache TTL (3600s) comfortably exceeds
+  this framework's own documented job-processing budgets today, so this is a latent risk, not a
+  live bug.
 
 ## Acceptance criteria
 
-- **AC-1** `get_session_key(session_id, notification_key=X)` with `source="context"` and a cache
-  miss returns `X` and caches it under `session_id` — no network call.
-- **AC-2** A subsequent call for the same `session_id` (with or without a fresh
-  `notification_key`) hits the cache.
-- **AC-3** `source="context"` with `notification_key=None` raises `ValueError` immediately.
-- **AC-4** `env`/`config`/`vault`/`remote` sources are unaffected — no behavior change for
-  existing consumers (VerA's deployment, per `agents-document-analyser`'s CLAUDE.md, stays on
-  whatever it currently uses).
-- **AC-5** Docstring's `Options:` line matches the actual branch list in code.
-- **AC-6** `JobNotification.session_key` defaults to `None` and does not break parsing of
-  notifications from a sessions-service version that doesn't send it.
+- **AC-1** `get_session_key(session_id, job_id=X)` with `source="job"` and a cache miss calls
+  `GET {remote_url}/internal/jobs/{X}/session-key` and returns the key from the response.
+- **AC-2** A subsequent call for the same `session_id` (different `job_id`, or none) hits the
+  cache and makes no HTTP call — this is now a correctness requirement, not just an optimization,
+  since a second real fetch would 404.
+- **AC-3** `source="job"` with no `job_id` raises `ValueError` before attempting any network call.
+- **AC-4** A 404 from the endpoint (already claimed / expired / unknown `job_id`) raises
+  `httpx.HTTPStatusError`, uncaught — the caller (`sessions_bus.py`) sees it as the job-processing
+  failure it actually is, not a swallowed no-op.
+- **AC-5** `env`/`config`/`vault`/`remote` sources are unaffected.
+- **AC-6** Docstring's `Options:` line matches the actual branch list in code.
 
 ## Constraints
 
-- Backward compatible: `notification_key` is optional and only required when
-  `source == "context"`; every other source's call signature and behavior is unchanged.
-- No new dependency (this version needs no `httpx` call at all, unlike r1).
+- Backward compatible: `job_id` is optional and only required when `source == "job"`.
+- No new dependency — `httpx` is already used by `_get_from_remote`.
+- **Named risk, not fixed here:** the single-use server contract means this framework's cache is
+  the sole holder of the key after first fetch. A cache eviction (TTL expiry) before all
+  processing for that session completes is unrecoverable under this design. Worth flagging back
+  to whoever owns this framework's deployment defaults if a consumer's job-processing latency
+  regularly approaches the cache TTL.
 
 ## Open questions
 
-None blocking — the server contract is settled by service-sessions#196's r2.
+None blocking — the server contract is settled by service-sessions#196's r3.
 
 ## Related issues
 
 - bechtleav360/avs.ai.project.pida#385 — where this was found live.
-- bechtleav360/avs.ai.idac.service-sessions#196 — the server-side change this depends on (r2, the
-  design that made this simpler).
+- bechtleav360/avs.ai.idac.service-sessions#196 — the server-side endpoint this depends on (r3).

--- a/docs/specs/2026-08-24-job-scoped-session-key-source.md
+++ b/docs/specs/2026-08-24-job-scoped-session-key-source.md
@@ -1,0 +1,132 @@
+# Spec: Add a job-scoped `"job"` source to `SessionKeyProvider`
+
+**Issue:** bechtleav360/AVS.AI.Blueprint.AgenticService#76
+**Depends on (server contract):** bechtleav360/avs.ai.idac.service-sessions#194
+
+## Goal
+
+Give `SessionKeyProvider` a working source for consumers whose session keys are generated fresh
+per session and actually validated (encryption enforced) — the current `env`/`config` sources
+only support one static key for every session, which cannot work for that case.
+
+## Why now
+
+Live-reproduced on `agents-document-analyser` against `avs.ai.idac.service-sessions`
+(bechtleav360/avs.ai.project.pida#385): a job is dispatched and received correctly over SSE, then
+`_process_job_notification` crashes immediately —
+
+```
+ValueError: Environment variable SESSION_KEY not set
+  File "blueprint/agents/services/sessions/key_provider.py", line 138, in _get_from_env
+```
+
+`env` (the default) and `config` both assume one static key shared by every session — wrong by
+construction once a consumer's sessions service issues (and validates) a distinct key per
+session, which `avs.ai.idac.service-sessions` does whenever its encryption policy is at its
+default (`storage.encryption_enabled=true`). `vault` raises `NotImplementedError`. `remote`
+(`_get_from_remote`, fetch by `session_id`) has no matching server endpoint on
+`avs.ai.idac.service-sessions` today, and building one that returns *any* session's key by id
+alone would sit awkwardly next to that service's own "zero-knowledge encrypted sessions" framing.
+
+## Root cause / gap
+
+The class docstring already gestures at the right shape — "Per-session keys passed via context
+(Phase 3)" — but it was never implemented: `get_session_key`'s branch list is only
+`env`/`config`/`vault`/`remote`, and the docstring's `Options:` line (`env, vault, context`) has
+also drifted from the actual code (missing `config` and `remote`, listing unimplemented
+`context`). Sessions-side, nothing currently carries a session key anywhere the agent could read
+it — not on the SSE notification, not anywhere else.
+
+## Design
+
+**New source: `"job"`.** Fetches the key from the job-scoped endpoint specified in
+bechtleav360/avs.ai.idac.service-sessions#194 (`GET /internal/jobs/{job_id}/session-key`,
+`X-Api-Key` auth) rather than adding a field to the broadcast/notification payload — see that
+spec's "Why not put the key on the existing broadcast" section for the reasoning (this framework
+is one of potentially several consumers of that service; the fetch-by-job-id shape is the
+contract being proposed there, not something this repo should quietly assume by adding fields to
+its own `JobNotification` model).
+
+```python
+# key_provider.py
+async def get_session_key(self, session_id: UUID | None = None, job_id: UUID | None = None) -> str:
+    ...
+    if self._source == "job":
+        session_key = await self._get_from_job(job_id)
+    ...
+
+async def _get_from_job(self, job_id: UUID | None) -> str:
+    if not job_id:
+        raise ValueError("job_id required for 'job' source")
+    if not self._remote_url:
+        raise ValueError("sessions_service.session_key_remote_url not configured")
+    url = f"{self._remote_url}/internal/jobs/{job_id}/session-key"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(url, headers={"X-Api-Key": self._api_key})
+        response.raise_for_status()
+        return response.json()["session_key"]
+```
+
+- `job_id` is a new optional parameter on `get_session_key`, threaded through from the three call
+  sites in `sessions_bus.py` (lines 377, 421, 445) — all three already have `job_id` in scope
+  from the notification they're handling.
+- **Caching is unchanged.** The existing cache keys by `session_id`, not by source — a `"job"`
+  fetch populates the same `TTLCache` under `str(session_id)`, so a second job in the same
+  session hits the cache without needing its `job_id` at all. Only the cache-miss path needs
+  `job_id`.
+- Reuses the existing `session_key_remote_url` / `api_key` config fields (already present for
+  `remote`) rather than adding new ones — same shape, different path suffix.
+- Fix the docstring's `Options:` line to list the actual implemented sources
+  (`env, config, vault, remote, job`) and drop the unimplemented `context` mention, or rename
+  `"job"` to `"context"` if the reviewer prefers keeping that name from the original design intent
+  — naming is not load-bearing, the fetch-by-job-id mechanism is.
+
+## In scope
+
+1. `job_id: UUID | None = None` parameter on `SessionKeyProvider.get_session_key`.
+2. New `_get_from_job` method + `"job"` branch.
+3. Update the three `sessions_bus.py` call sites to pass `job_id=notification.job_id`.
+4. Correct the class docstring's `Options:` line.
+5. Unit tests: cache hit skips the fetch entirely (job_id not required in that path), `"job"`
+   source with no `job_id` raises `ValueError`, successful fetch caches under `session_id`,
+   non-2xx response propagates as `httpx.HTTPStatusError` (consistent with `_get_from_remote`'s
+   existing behavior — not swallowed).
+
+## Out of scope
+
+- The server-side endpoint itself — bechtleav360/avs.ai.idac.service-sessions#194, this repo only
+  consumes it.
+- `vault` implementation (unrelated pre-existing gap).
+- Any change to `JobNotification`'s fields — deliberately not adding `session_key` there, see
+  Design above.
+- Retry/backoff policy for the fetch — matches `_get_from_remote`'s current (no-retry) behavior;
+  a separate concern if it needs hardening.
+
+## Acceptance criteria
+
+- **AC-1** `get_session_key(session_id, job_id=X)` with `source="job"` and a cache miss calls
+  `GET {remote_url}/internal/jobs/{X}/session-key` and returns the key from the response.
+- **AC-2** A subsequent call for the same `session_id` (different `job_id`, or none) hits the
+  cache and makes no HTTP call.
+- **AC-3** `source="job"` with no `job_id` raises `ValueError` before attempting any network call.
+- **AC-4** `env`/`config`/`vault`/`remote` sources are unaffected — no behavior change for
+  existing consumers (VerA's deployment, per `agents-document-analyser`'s CLAUDE.md, stays on
+  whatever it currently uses).
+- **AC-5** Docstring's `Options:` line matches the actual branch list in code.
+
+## Constraints
+
+- Backward compatible: `job_id` is optional and only required when `source == "job"`; every other
+  source's call signature and behavior is unchanged.
+- No new dependency — `httpx` is already used by `_get_from_remote`.
+
+## Open questions
+
+- Confirm the endpoint path/prefix (`/internal/...` vs. something else) once
+  bechtleav360/avs.ai.idac.service-sessions#194's spec is approved — this repo's `_get_from_job`
+  should match whatever that spec lands on.
+
+## Related issues
+
+- bechtleav360/avs.ai.project.pida#385 — where this was found live.
+- bechtleav360/avs.ai.idac.service-sessions#194 — the server-side endpoint this depends on.

--- a/docs/specs/2026-08-24-job-scoped-session-key-source.md
+++ b/docs/specs/2026-08-24-job-scoped-session-key-source.md
@@ -2,7 +2,7 @@
 
 **Issue:** bechtleav360/AVS.AI.Blueprint.AgenticService#76
 **Companion (server contract):** bechtleav360/avs.ai.idac.service-sessions#196
-**Status:** spec r3 — supersedes r2 (r2's server-side dependency was DENY'd; see below)
+**Status:** spec r4 — supersedes r3 (server contract changed again; see below)
 
 ## Goal
 
@@ -21,34 +21,37 @@ ValueError: Environment variable SESSION_KEY not set
   File "blueprint/agents/services/sessions/key_provider.py", line 138, in _get_from_env
 ```
 
-## r2 → r3: the server-side dependency changed shape again
+## r3 → r4: the server contract added agent-scoped claiming and a new status code
 
-r2 proposed reading `session_key` directly off the `job_created` SSE notification, because the
-server-side companion spec's r2 (service-sessions#196) attached it there. That server-side r2 was
-DENY'd: the agent SSE channel's replay buffer turned out to have no per-recipient access control
-(a process-wide, capability-filtered-only 500-entry ring buffer, replayable by any `X-Api-Key`
-holder via auto-registration), so putting a raw session key in that payload would have made every
-dispatched key bulk-harvestable. The server-side r3 instead keeps `job_created` **completely
-unchanged** and introduces a one-time, short-lived (15 min TTL), single-use fetch:
-`GET /internal/jobs/{job_id}/session-key`, backed by storage that never touches the broadcast
-path. Full reasoning in service-sessions#196's r3.
+service-sessions#196 went through a further review round after r3 was written. Two more findings
+there (a guardrail blind spot, and a security gap where the fetch endpoint could turn a
+harvested `job_id` into a live session key) resulted in:
 
-This reverts this repo's side back to a fetch-based source (closer to r1's shape, not r2's) — but
-against a real, correctly-scoped endpoint this time, not r1's endpoint whose premise didn't hold.
+- The endpoint gained a required `agent_id` query parameter — the *first* caller to fetch a given
+  `job_id` claims it; later calls from a different `agent_id` get **409**, not the key. This
+  narrows (doesn't cryptographically close — `agent_id` is self-declared) the risk that a
+  `job_id` harvested via the SSE replay buffer could be traded for a live key by someone other
+  than the actually-dispatched agent.
+- The fetch is no longer single-use — repeat calls from the *same* `agent_id` within the 15-minute
+  TTL window succeed (server-side r4/r5 change, made for crash/cache-eviction recoverability).
+  This actually **removes** r3's biggest named risk here (client cache as sole holder of the key)
+  — see Constraints.
+
+This repo's side needs one addition over r3: pass this agent's own `agent_id` on the fetch, and
+handle 409 as a distinct, real outcome (not just another failure to raise-and-forget).
 
 ## Root cause / gap (unchanged since r1)
 
 The class docstring already gestures at the right shape — "Per-session keys passed via context
 (Phase 3)" — but it was never implemented: `get_session_key`'s branch list is only
 `env`/`config`/`vault`/`remote`, and the docstring's `Options:` line (`env, vault, context`) has
-also drifted from the actual code (missing `config` and `remote`, listing unimplemented
-`context`).
+also drifted from the actual code.
 
 ## Design
 
-**New source: `"job"`.** Fetches the key once via
-`GET {remote_url}/internal/jobs/{job_id}/session-key` (`X-Api-Key` auth), per
-service-sessions#196's r3 contract:
+**New source: `"job"`.** Fetches the key via
+`GET {remote_url}/internal/jobs/{job_id}/session-key?agent_id=<this agent's own id>`
+(`X-Api-Key` auth), per service-sessions#196's current contract:
 
 ```python
 async def get_session_key(
@@ -73,79 +76,97 @@ async def _get_from_job(self, job_id: UUID | None) -> str:
         raise ValueError("job_id required for 'job' source")
     if not self._remote_url:
         raise ValueError("sessions_service.session_key_remote_url not configured")
+    if not self._agent_id:
+        raise ValueError("agent_id not set — SessionKeyProvider must be started after SessionsBus")
     url = f"{self._remote_url}/internal/jobs/{job_id}/session-key"
     async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(url, headers={"X-Api-Key": self._api_key})
-        response.raise_for_status()  # 404 (already claimed / expired / unknown) raises here
+        response = await client.get(
+            url, params={"agent_id": self._agent_id}, headers={"X-Api-Key": self._api_key}
+        )
+        if response.status_code == 409:
+            raise SessionKeyClaimConflictError(
+                f"job {job_id}'s session key was already claimed by a different agent"
+            )
+        response.raise_for_status()  # 404 (expired/unknown) raises here
         return response.json()["session_key"]
 ```
 
-- `job_id` is a new optional parameter on `get_session_key`, threaded from the three call sites in
-  `sessions_bus.py` (lines 377, 421, 445) — all three already have `job_id` in scope from the
-  notification they're handling.
-- **The fetch is single-use server-side** (service-sessions#196 AC-2) — a second call for the
-  same `job_id` 404s. This makes the client-side cache load-bearing in a way it wasn't for
-  `env`/`config`/`remote`: once fetched, the cached value is the *only* copy this process can
-  still obtain for that session. If the cache entry is evicted (TTL, default 3600s) before every
-  job needing that key has been processed, there is no recovery — a retry would hit the
-  already-consumed endpoint and 404. See Constraints.
-- Reuses the existing `session_key_remote_url` / `api_key` config fields (already present for
-  `remote`) rather than adding new ones.
+- **`self._agent_id`**: `SessionKeyProvider` needs the same `agent_id` `SessionsBus` already
+  tracks (`sessions_bus.py:65,85`). Threaded in at construction/startup rather than duplicating
+  config resolution — `SessionsBus` passes its own `self._agent_id` to the key provider it owns,
+  or both read the same `sessions_config.agent_id` value. Either wiring works; the concrete choice
+  is an implementation detail, not a design question.
+- **New exception**: `SessionKeyClaimConflictError` (409) is distinct from "not found/expired"
+  (404, `httpx.HTTPStatusError`) — a caller catching this can log "another agent instance already
+  claimed this job" rather than treating it identically to "the key is simply gone." Only relevant
+  today if this agent type is ever scaled to multiple replicas of one capability (not the current
+  deployment shape, per pida's own document-analyser CLAUDE.md).
+- `job_id` remains a new optional parameter on `get_session_key`, threaded from the three call
+  sites in `sessions_bus.py` (lines 377, 421, 445) — unchanged from r3.
+- **Caching is now genuinely just an optimization again**, not a correctness requirement — see r3
+  vs. r4 in Constraints. The server no longer discards the key on first read, so a cache miss on a
+  later call for the same `job_id`/`agent_id` simply re-fetches successfully instead of 404ing.
 - Fix the docstring's `Options:` line to list the actual implemented sources
-  (`env, config, vault, remote, job`) and drop the unimplemented `context` mention.
+  (`env, config, vault, remote, job`).
 
 ## In scope
 
 1. `job_id: UUID | None = None` parameter on `SessionKeyProvider.get_session_key`.
-2. New `_get_from_job` method + `"job"` branch.
-3. Update the three `sessions_bus.py` call sites to pass `job_id=notification.job_id`.
-4. Correct the class docstring's `Options:` line.
-5. Unit tests: cache hit skips the fetch entirely; `"job"` source with no `job_id` raises
-   `ValueError` before any network call; successful fetch caches under `session_id`; a 404
-   response (already-claimed/expired/unknown) propagates as `httpx.HTTPStatusError` rather than
-   being swallowed or silently retried (a silent retry would always 404 given single-use — a
-   test should assert there is no retry loop here).
+2. `self._agent_id` available to `SessionKeyProvider` (wired from `SessionsBus` or shared config).
+3. New `_get_from_job` method + `"job"` branch, sending `agent_id` and handling 409 distinctly
+   from 404.
+4. New `SessionKeyClaimConflictError`.
+5. Update the three `sessions_bus.py` call sites to pass `job_id=notification.job_id`.
+6. Correct the class docstring's `Options:` line.
+7. Unit tests: cache hit skips the fetch; `"job"` source with no `job_id` raises `ValueError`
+   before any network call; missing `agent_id` raises `ValueError` before any network call; 409
+   raises `SessionKeyClaimConflictError`, not swallowed or conflated with 404; successful fetch
+   caches under `session_id`; a repeat fetch after a cache miss (simulating eviction) for the same
+   `job_id`/`agent_id` succeeds rather than assuming failure (r4 behavior change from r3).
 
 ## Out of scope
 
 - The server-side endpoint and its storage — service-sessions#196, this repo only consumes it.
+- The pre-existing SSE replay/auto-registration identity gap the server-side spec names as the
+  residual risk this narrows — service-sessions#198, a server-side fix, nothing to do here.
 - `vault` implementation (unrelated pre-existing gap).
 - `remote`/`_get_from_remote` — left in place, unused by any current consumer.
-- Cache-eviction-vs-single-use hardening (e.g. pinning the TTL for `"job"`-sourced entries higher
-  than the default, or re-deriving from a fresh notification if one arrives) — flagged in
-  Constraints as a real gap, not solved here; the default cache TTL (3600s) comfortably exceeds
-  this framework's own documented job-processing budgets today, so this is a latent risk, not a
-  live bug.
 
 ## Acceptance criteria
 
 - **AC-1** `get_session_key(session_id, job_id=X)` with `source="job"` and a cache miss calls
-  `GET {remote_url}/internal/jobs/{X}/session-key` and returns the key from the response.
-- **AC-2** A subsequent call for the same `session_id` (different `job_id`, or none) hits the
-  cache and makes no HTTP call — this is now a correctness requirement, not just an optimization,
-  since a second real fetch would 404.
-- **AC-3** `source="job"` with no `job_id` raises `ValueError` before attempting any network call.
-- **AC-4** A 404 from the endpoint (already claimed / expired / unknown `job_id`) raises
-  `httpx.HTTPStatusError`, uncaught — the caller (`sessions_bus.py`) sees it as the job-processing
-  failure it actually is, not a swallowed no-op.
-- **AC-5** `env`/`config`/`vault`/`remote` sources are unaffected.
-- **AC-6** Docstring's `Options:` line matches the actual branch list in code.
+  `GET {remote_url}/internal/jobs/{X}/session-key?agent_id=<self>` and returns the key.
+- **AC-2** A subsequent call for the same `session_id` hits the cache and makes no HTTP call.
+- **AC-3** `source="job"` with no `job_id` raises `ValueError` before any network call.
+- **AC-4** `agent_id` unset raises `ValueError` before any network call.
+- **AC-5** A 409 response raises `SessionKeyClaimConflictError`, distinguishable from the 404
+  case (`httpx.HTTPStatusError`).
+- **AC-6** A cache miss for a `job_id` already successfully fetched once (simulating eviction)
+  succeeds on retry — no longer assumed to 404, since the server is no longer single-use.
+- **AC-7** `env`/`config`/`vault`/`remote` sources are unaffected.
+- **AC-8** Docstring's `Options:` line matches the actual branch list in code.
 
 ## Constraints
 
 - Backward compatible: `job_id` is optional and only required when `source == "job"`.
 - No new dependency — `httpx` is already used by `_get_from_remote`.
-- **Named risk, not fixed here:** the single-use server contract means this framework's cache is
-  the sole holder of the key after first fetch. A cache eviction (TTL expiry) before all
-  processing for that session completes is unrecoverable under this design. Worth flagging back
-  to whoever owns this framework's deployment defaults if a consumer's job-processing latency
-  regularly approaches the cache TTL.
+- **r3's named risk is resolved, not just documented, by the server-side change**: since the
+  server fetch is no longer single-use, a cache eviction before job completion is now recoverable
+  (a fresh fetch with the same `agent_id` succeeds). r3's "cache is the sole holder of the key"
+  framing no longer applies.
+- **New, smaller residual risk**: if this agent type ever runs multiple replicas of one
+  capability, whichever replica's `agent_id` claims a `job_id` first is the only one that can
+  fetch it again — a replica that didn't win the race gets 409 forever for that job, even though
+  it's the one actually processing it (if job routing and key-claiming ever get out of sync
+  between replicas). Not reachable in today's single-instance-per-capability deployment.
 
 ## Open questions
 
-None blocking — the server contract is settled by service-sessions#196's r3.
+None blocking — the server contract is settled by service-sessions#196's current revision.
 
 ## Related issues
 
 - bechtleav360/avs.ai.project.pida#385 — where this was found live.
-- bechtleav360/avs.ai.idac.service-sessions#196 — the server-side endpoint this depends on (r3).
+- bechtleav360/avs.ai.idac.service-sessions#196 — the server-side endpoint this depends on.
+- bechtleav360/avs.ai.idac.service-sessions#198 — the residual identity-scoping gap, server-side,
+  nothing to build here.


### PR DESCRIPTION
## Summary
- Spec-only PR, no code changes. Proposes a new `"job"` source for `SessionKeyProvider`, fetching per-session keys via the endpoint proposed in bechtleav360/avs.ai.idac.service-sessions#194 instead of relying on a static env/config key — which cannot work once a consumer's sessions service issues a distinct key per session (live-reproduced crash: `ValueError: Environment variable SESSION_KEY not set`, see #76).
- Also flags and proposes fixing the drift between this class's docstring (`Options: env, vault, context`) and its actual implemented branches (`env, config, vault, remote`) — `context` was never implemented despite being documented.

Companion spec on the server side: bechtleav360/avs.ai.idac.service-sessions#194 (their PR is the one defining the actual endpoint contract).

## Test plan
- N/A — spec document only, review the design before any implementation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)