### PR TITLE
Add "job" source to SessionKeyProvider (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+- **`SessionKeyProvider` gains a `"job"` source** (#76). `env`/`config` only ever supported one static key for every session, which cannot work for consumers whose session keys are generated fresh per session and actually validated (encryption enforced) — the gap live-reproduced as `ValueError: Environment variable SESSION_KEY not set` immediately after a job dispatch (bechtleav360/avs.ai.project.pida#385). `source = "job"` fetches the key via `GET {session_key_remote_url}/internal/jobs/{job_id}/session-key?agent_id=<this agent's own id>` (bechtleav360/avs.ai.idac.service-sessions#194 Finding 2 / #196), threading a new optional `job_id` parameter through `get_session_key` from `SessionsBus`'s three call sites. A 409 (job already claimed by a different `agent_id`) raises the new `SessionKeyClaimConflictError`, distinct from the 404/`httpx.HTTPStatusError` case. `env`/`config`/`vault`/`remote` sources are unaffected.
+
 ## [0.6.4] - 2026-07-29
 
 ### Fixed

--- a/src/blueprint/agents/io/api/eventing/sessions_bus.py
+++ b/src/blueprint/agents/io/api/eventing/sessions_bus.py
@@ -374,7 +374,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
             event = self._convert_to_cloud_event(notification)
 
             try:
-                session_key = await self._require_key_provider().get_session_key(session_id)
+                session_key = await self._require_key_provider().get_session_key(session_id, job_id=job_id)
                 context = self._build_context(session_id, job_id, session_key, pipeline_id=notification.pipeline_id)
                 result = await self._dispatch_cloud_event(event, context)
 
@@ -418,7 +418,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
     async def _cancel_invalid_job(self, session_id: UUID, job_id: UUID, error: InvalidEventError) -> None:
         logger.error("Invalid job %s: %s. Cancelling.", job_id, error)
         try:
-            session_key = await self._require_key_provider().get_session_key(session_id)
+            session_key = await self._require_key_provider().get_session_key(session_id, job_id=job_id)
             await self._require_api_client().cancel_job(
                 session_id=session_id,
                 job_id=job_id,
@@ -442,7 +442,7 @@ class SessionsBus(Component, CloudEventProcessorMixin):
         key_provider = self._require_key_provider()
         key_provider.invalidate_cache(session_id)
         try:
-            session_key = await key_provider.get_session_key(session_id)
+            session_key = await key_provider.get_session_key(session_id, job_id=job_id)
             context = self._build_context(session_id, job_id, session_key, pipeline_id=pipeline_id)
             await self._dispatch_cloud_event(event, context)
         except Exception as retry_error:

--- a/src/blueprint/agents/services/sessions/__init__.py
+++ b/src/blueprint/agents/services/sessions/__init__.py
@@ -6,9 +6,10 @@ This module provides all components needed for integrating with the sessions ser
 """
 
 from .api_client import SessionsApiClient
-from .key_provider import SessionKeyProvider
+from .key_provider import SessionKeyClaimConflictError, SessionKeyProvider
 
 __all__ = [
-    "SessionsApiClient",
+    "SessionKeyClaimConflictError",
     "SessionKeyProvider",
+    "SessionsApiClient",
 ]

--- a/src/blueprint/agents/services/sessions/key_provider.py
+++ b/src/blueprint/agents/services/sessions/key_provider.py
@@ -18,6 +18,14 @@ from ..service_base import ServiceBase
 logger = logging.getLogger(__name__)
 
 
+class SessionKeyClaimConflictError(Exception):
+    """Raised when a ``"job"`` source fetch returns 409: the job's session key was already
+    claimed by a different ``agent_id``. Distinct from the 404 case (``httpx.HTTPStatusError``,
+    raised via ``response.raise_for_status()``) — a caller catching this specifically can log
+    "another agent instance already claimed this job" instead of treating it identically to
+    "the key is simply gone."""
+
+
 class SessionKeyProvider(ServiceBase):
     """Provides session keys from configured source.
 
@@ -25,15 +33,17 @@ class SessionKeyProvider(ServiceBase):
     - Environment variables (Phase 1)
     - Configuration files
     - External vault (Phase 2 - HashiCorp Vault, Azure Key Vault)
+    - Job-scoped keys fetched from the sessions service ("job")
     - Per-session keys passed via context (Phase 3)
 
     Includes caching with TTL and 403-based invalidation for performance.
 
     Configuration (settings.toml):
         [sessions_service]
-        session_key_source = "env"  # Options: env, vault, context
+        session_key_source = "env"  # Options: env, config, vault, remote, job
         session_key_env_var = "SESSION_KEY"
         session_key_cache_ttl_seconds = 3600
+        agent_id = "..."  # required when session_key_source = "job"
     """
 
     def __init__(self) -> None:
@@ -44,6 +54,7 @@ class SessionKeyProvider(ServiceBase):
         self._cache_ttl: int = 3600
         self._remote_url: str = ""
         self._api_key: str = ""
+        self._agent_id: str = ""
 
     async def on_startup(self) -> None:
         """Initialize the session key provider with configuration."""
@@ -56,6 +67,10 @@ class SessionKeyProvider(ServiceBase):
         self._cache_ttl = config.get("session_key_cache_ttl_seconds", 3600)
         self._remote_url = config.get("session_key_remote_url", "")
         self._api_key = config.get("api_key", "")
+        # Same config key SessionsBus reads for its own agent_id (sessions_service.agent_id) —
+        # read independently rather than pulled from SessionsBus at runtime, since this service
+        # starts before SessionsBus (a routerless lifecycle component) in the app lifespan.
+        self._agent_id = config.get("agent_id", "")
 
         # Initialize cache
         self._cache = TTLCache(maxsize=1000, ttl=self._cache_ttl)
@@ -72,17 +87,21 @@ class SessionKeyProvider(ServiceBase):
             self._cache.clear()
         logger.info("SessionKeyProvider shut down")
 
-    async def get_session_key(self, session_id: UUID | None = None) -> str:
+    async def get_session_key(self, session_id: UUID | None = None, job_id: UUID | None = None) -> str:
         """Get session key for a specific session or default key.
 
         Args:
             session_id: Optional session ID for per-session keys
+            job_id: Job ID to fetch a job-scoped key for (required when
+                ``session_key_source == "job"``; ignored by every other source)
 
         Returns:
             Session key string
 
         Raises:
             ValueError: If session key cannot be retrieved
+            SessionKeyClaimConflictError: ``"job"`` source only — the job's key was already
+                claimed by a different ``agent_id`` (HTTP 409)
         """
         cache_key = str(session_id) if session_id else "default"
 
@@ -92,7 +111,9 @@ class SessionKeyProvider(ServiceBase):
             return self._cache[cache_key]
 
         # Fetch from source
-        if self._source == "env":
+        if self._source == "job":
+            session_key = await self._get_from_job(job_id)
+        elif self._source == "env":
             session_key = self._get_from_env()
         elif self._source == "config":
             session_key = self._get_from_config()
@@ -202,4 +223,39 @@ class SessionKeyProvider(ServiceBase):
             data = response.json()
 
         logger.debug("Session key retrieved from remote: session_id=%s", session_id)
+        return data["session_key"]
+
+    async def _get_from_job(self, job_id: UUID | None) -> str:
+        """Fetch a job-scoped session key from the sessions service's agent-claimed handoff
+        endpoint (bechtleav360/avs.ai.idac.service-sessions#194 Finding 2 / #196).
+
+        Args:
+            job_id: Job ID to fetch the key for.
+
+        Returns:
+            Session key string.
+
+        Raises:
+            ValueError: If job_id is None, agent_id is unset, or remote_url not configured.
+            SessionKeyClaimConflictError: The job's key was already claimed by a different
+                agent_id (HTTP 409).
+            httpx.HTTPStatusError: Any other non-2xx response, notably 404 (expired/unknown job).
+        """
+        if not job_id:
+            raise ValueError("job_id required for 'job' source")
+        if not self._remote_url:
+            raise ValueError("sessions_service.session_key_remote_url not configured")
+        if not self._agent_id:
+            raise ValueError("sessions_service.agent_id not configured — required for session_key_source='job'")
+
+        url = f"{self._remote_url}/internal/jobs/{job_id}/session-key"
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url, params={"agent_id": self._agent_id}, headers={"X-Api-Key": self._api_key})
+            if response.status_code == 409:
+                raise SessionKeyClaimConflictError(f"job {job_id}'s session key was already claimed by a different agent")
+            response.raise_for_status()  # 404 (expired/unknown) raises here
+            data = response.json()
+
+        logger.debug("Session key retrieved for job: job_id=%s, agent_id=%s", job_id, self._agent_id)
         return data["session_key"]

--- a/tests/unit/agents/io/api/eventing/test_sessions_bus.py
+++ b/tests/unit/agents/io/api/eventing/test_sessions_bus.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from uuid import UUID, uuid4
 
 import httpx
@@ -195,6 +195,19 @@ class TestProcessJobNotification:
 
         assert "No handler found" in caplog.text
 
+    async def test_get_session_key_receives_job_id(
+        self,
+        started_sessions_bus: SessionsBus,
+        notification: JobNotification,
+    ) -> None:
+        """#76: the happy-path fetch threads job_id through so a "job" source can claim it."""
+        result = ProcessingResult(request_id="r", status=ProcessingStatus.PROCESSED)
+        started_sessions_bus._dispatch_cloud_event = AsyncMock(return_value=result)  # type: ignore[method-assign]
+
+        await started_sessions_bus._process_job_notification(notification)
+
+        started_sessions_bus._key_provider.get_session_key.assert_awaited_once_with(notification.session_id, job_id=notification.job_id)
+
     async def test_invalid_event_error_cancels_job(
         self,
         started_sessions_bus: SessionsBus,
@@ -208,6 +221,10 @@ class TestProcessJobNotification:
         started_sessions_bus._api_client.cancel_job.assert_awaited_once()
         call_kwargs = started_sessions_bus._api_client.cancel_job.call_args.kwargs
         assert call_kwargs["job_id"] == notification.job_id
+        # #76: _cancel_invalid_job's own key fetch also threads job_id through (get_session_key
+        # is called twice overall here — once in the main try block, once inside cancel — both
+        # with the same args, so assert on the most recent call rather than requiring exactly one).
+        started_sessions_bus._key_provider.get_session_key.assert_awaited_with(notification.session_id, job_id=notification.job_id)
 
     async def test_invalid_event_error_cancel_failure_is_swallowed(
         self,
@@ -248,6 +265,10 @@ class TestProcessJobNotification:
 
         started_sessions_bus._key_provider.invalidate_cache.assert_called_once()
         assert started_sessions_bus._dispatch_cloud_event.await_count == 2
+        # #76: the retry's own fresh-key fetch also threads job_id through.
+        assert started_sessions_bus._key_provider.get_session_key.await_args_list[-1] == call(
+            notification.session_id, job_id=notification.job_id
+        )
 
     async def test_403_retry_failure_propagates_invalid_event_error(
         self, started_sessions_bus: SessionsBus, notification: JobNotification

--- a/tests/unit/agents/services/sessions/test_key_provider.py
+++ b/tests/unit/agents/services/sessions/test_key_provider.py
@@ -9,7 +9,7 @@ import pytest
 import respx
 from cachetools import TTLCache
 
-from blueprint.agents.services.sessions.key_provider import SessionKeyProvider
+from blueprint.agents.services.sessions.key_provider import SessionKeyClaimConflictError, SessionKeyProvider
 
 _SESSION_ID = UUID("00000000-0000-0000-0000-000000000001")
 
@@ -220,3 +220,107 @@ class TestGetSessionKeyRemote:
         provider = _make_remote_provider(remote_url="")
         with pytest.raises(ValueError, match="session_key_remote_url not configured"):
             await provider.get_session_key(uuid4())
+
+
+# ---------------------------------------------------------------------------
+# get_session_key — job source (bechtleav360/AVS.AI.Blueprint.AgenticService#76,
+# bechtleav360/avs.ai.idac.service-sessions#194 Finding 2 / #196)
+# ---------------------------------------------------------------------------
+
+_JOB_REMOTE_URL = "http://sessions.local:8001"
+
+
+def _make_job_provider(remote_url: str = _JOB_REMOTE_URL, api_key: str = "test-key", agent_id: str = "agent-1") -> SessionKeyProvider:
+    provider = SessionKeyProvider()
+    provider._source = "job"
+    provider._remote_url = remote_url
+    provider._api_key = api_key
+    provider._agent_id = agent_id
+    provider._cache = TTLCache(maxsize=100, ttl=60)
+    return provider
+
+
+class TestGetSessionKeyJob:
+    @respx.mock
+    async def test_returns_key_from_job_endpoint(self) -> None:
+        job_id = uuid4()
+        respx.get(f"{_JOB_REMOTE_URL}/internal/jobs/{job_id}/session-key").mock(
+            return_value=httpx.Response(200, json={"session_key": "job-secret"})
+        )
+        provider = _make_job_provider()
+        result = await provider.get_session_key(uuid4(), job_id=job_id)
+        assert result == "job-secret"
+
+    @respx.mock
+    async def test_sends_agent_id_and_api_key(self) -> None:
+        job_id = uuid4()
+        route = respx.get(f"{_JOB_REMOTE_URL}/internal/jobs/{job_id}/session-key").mock(
+            return_value=httpx.Response(200, json={"session_key": "job-secret"})
+        )
+        provider = _make_job_provider(agent_id="agent-42", api_key="sekrit")
+        await provider.get_session_key(uuid4(), job_id=job_id)
+        request = route.calls.last.request
+        assert request.url.params["agent_id"] == "agent-42"
+        assert request.headers["X-Api-Key"] == "sekrit"
+
+    @respx.mock
+    async def test_caches_key_under_session_id_after_first_fetch(self) -> None:
+        session_id = uuid4()
+        job_id = uuid4()
+        route = respx.get(f"{_JOB_REMOTE_URL}/internal/jobs/{job_id}/session-key").mock(
+            return_value=httpx.Response(200, json={"session_key": "job-secret"})
+        )
+        provider = _make_job_provider()
+        await provider.get_session_key(session_id, job_id=job_id)
+        await provider.get_session_key(session_id, job_id=job_id)
+        assert route.call_count == 1  # AC-2: cache hit skips the fetch
+
+    async def test_raises_when_job_id_missing_before_any_network_call(self) -> None:
+        """AC-3: no job_id -> ValueError, no HTTP attempted (no respx mock registered at all)."""
+        provider = _make_job_provider()
+        with pytest.raises(ValueError, match="job_id required"):
+            await provider.get_session_key(uuid4(), job_id=None)
+
+    async def test_raises_when_agent_id_missing_before_any_network_call(self) -> None:
+        """AC-4: no agent_id -> ValueError, no HTTP attempted."""
+        provider = _make_job_provider(agent_id="")
+        with pytest.raises(ValueError, match="agent_id not configured"):
+            await provider.get_session_key(uuid4(), job_id=uuid4())
+
+    async def test_raises_when_remote_url_missing_before_any_network_call(self) -> None:
+        provider = _make_job_provider(remote_url="")
+        with pytest.raises(ValueError, match="session_key_remote_url not configured"):
+            await provider.get_session_key(uuid4(), job_id=uuid4())
+
+    @respx.mock
+    async def test_409_raises_claim_conflict_not_http_status_error(self) -> None:
+        """AC-5: 409 is SessionKeyClaimConflictError, distinguishable from the 404/HTTPStatusError
+        case — a caller catching this specifically can log a claim conflict, not "gone"."""
+        job_id = uuid4()
+        respx.get(f"{_JOB_REMOTE_URL}/internal/jobs/{job_id}/session-key").mock(return_value=httpx.Response(409))
+        provider = _make_job_provider()
+        with pytest.raises(SessionKeyClaimConflictError):
+            await provider.get_session_key(uuid4(), job_id=job_id)
+
+    @respx.mock
+    async def test_404_raises_http_status_error_not_claim_conflict(self) -> None:
+        job_id = uuid4()
+        respx.get(f"{_JOB_REMOTE_URL}/internal/jobs/{job_id}/session-key").mock(return_value=httpx.Response(404))
+        provider = _make_job_provider()
+        with pytest.raises(httpx.HTTPStatusError):
+            await provider.get_session_key(uuid4(), job_id=job_id)
+
+    @respx.mock
+    async def test_repeat_fetch_after_cache_eviction_succeeds(self) -> None:
+        """r4 behavior change from r3: the server is no longer single-use, so a second fetch for
+        the same job_id/agent_id (simulating a client-side cache eviction) must succeed, not be
+        assumed to 404."""
+        job_id = uuid4()
+        route = respx.get(f"{_JOB_REMOTE_URL}/internal/jobs/{job_id}/session-key").mock(
+            return_value=httpx.Response(200, json={"session_key": "job-secret"})
+        )
+        provider = _make_job_provider()
+        first = await provider._get_from_job(job_id)
+        second = await provider._get_from_job(job_id)  # bypasses the cache directly, as an eviction would
+        assert first == second == "job-secret"
+        assert route.call_count == 2


### PR DESCRIPTION
## Summary
- Implements the merged spec r4 (`docs/specs/2026-08-24-job-scoped-session-key-source.md`) for #76: `SessionKeyProvider` gains a `"job"` source, fetching a job-scoped key from the sessions service's new agent-claimed handoff endpoint (bechtleav360/avs.ai.idac.service-sessions#194 Finding 2, server-side companion PR bechtleav360/avs.ai.idac.service-sessions#200) instead of assuming one static key works for every session.
- Closes the crash live-reproduced on `agents-document-analyser` (pida#385): `ValueError: Environment variable SESSION_KEY not set` immediately after a job dispatch — `env`/`config` only ever supported one static key for every session, which can't work for a consumer whose session keys are generated fresh per session and actually validated.
- `job_id` threaded through `get_session_key` from all 3 `SessionsBus` call sites (`_process_job_notification`, `_cancel_invalid_job`, `_retry_with_fresh_key`).
- `agent_id` resolved independently from `sessions_service` config (the same key `SessionsBus` reads for its own `agent_id`), not pulled from `SessionsBus` at runtime — `SessionKeyProvider` (a `Service`) starts before `SessionsBus` (a routerless lifecycle component) in the app lifespan, so runtime coupling wasn't an option.
- New `SessionKeyClaimConflictError` for HTTP 409 (job already claimed by a different `agent_id`), distinct from the 404/`httpx.HTTPStatusError` case, exported from `services.sessions`.
- `env`/`config`/`vault`/`remote` sources are unaffected.

## Test plan
- [x] New unit tests in `tests/unit/agents/services/sessions/test_key_provider.py` (`TestGetSessionKeyJob`): successful fetch, agent_id/api_key sent correctly, cache-hit skips the fetch, missing `job_id`/`agent_id`/`remote_url` each raise `ValueError` before any network call, 409 raises `SessionKeyClaimConflictError` distinguishable from 404's `httpx.HTTPStatusError`, and a repeat fetch after a simulated cache eviction succeeds (server is no longer single-use).
- [x] New assertions in `tests/unit/agents/io/api/eventing/test_sessions_bus.py` confirming `job_id` is threaded through at all 3 `get_session_key` call sites.
- [x] `uv run pytest tests/ -m "not integration"` — zero new failures vs. a clean `develop` baseline (29 pre-existing `tests/integration/examples/` failures, unrelated to this change, present on both).
- [x] `ruff check`, `black --check`, `mypy` — clean on every file this PR touches.

Related: #76, bechtleav360/avs.ai.idac.service-sessions#194, bechtleav360/avs.ai.idac.service-sessions#200 (server-side companion, implements the endpoint this PR consumes).

https://claude.ai/code/session_01Lts14pxVcpmnm423xR2xek