### PR TITLE
fix(config): redact input value from sessions_service validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 ## [Unreleased]
 
-## [0.8.0] - 2026-09-04
+## [0.8.0] - 2026-09-07
 
 ### Added
-- **`Config.get_sessions_config()` typed accessor for the `[sessions_service]` block** (#87). `Config` already exposed a typed getter for every other config block (`get_ai_config`, `get_cache_config`, `get_observability_config`, `get_event_publishing_config`, `get_prompt_config`, `get_nats_subscription_config`) — sessions was the one gap, even though `SessionsServiceConfig` already shipped. The new getter reads and validates the block against `SessionsServiceConfig`, so downstream agents running in `event_bus = "sessions"` mode can retire the local wrappers they hand-rolled to read the raw `sessions_service` sub-dict (which duplicated the framework's field/default contract and drifted from upstream defaults). Behaviour on an **absent** block is `None` (not an error) — REST-only agents never configure sessions, so absence graceful-degrades rather than raising; a **present but invalid** block (e.g. missing a required `base_url` / `api_key` / `agent_id`) fails fast as a `ConfigError`. Unblocks bechtleav360/avs.ai.idac.agents-document-classifier#44.
+- **`Config.get_sessions_config()` typed accessor for the `[sessions_service]` block** (#87). `Config` already exposed a typed getter for every other config block (`get_ai_config`, `get_cache_config`, `get_observability_config`, `get_event_publishing_config`, `get_prompt_config`, `get_nats_subscription_config`) — sessions was the one gap, even though `SessionsServiceConfig` already shipped. The new getter reads and validates the block against `SessionsServiceConfig`, so downstream agents running in `event_bus = "sessions"` mode can retire the local wrappers they hand-rolled to read the raw `sessions_service` sub-dict (which duplicated the framework's field/default contract and drifted from upstream defaults). Behaviour on an **absent** block is `None` (not an error) — REST-only agents never configure sessions, so absence graceful-degrades rather than raising; a **present but invalid** block (e.g. missing a required `base_url` / `api_key` / `agent_id`) fails fast as a `ConfigError`. Validation errors report field/type only — never the offending input value — so a mistyped `api_key` cannot leak a secret into logs or the error message. Unblocks bechtleav360/avs.ai.idac.agents-document-classifier#44.
 
 ## [0.7.0] - 2026-09-04
 

--- a/src/blueprint/agents/config/config.py
+++ b/src/blueprint/agents/config/config.py
@@ -465,8 +465,13 @@ class Config:
         try:
             return SessionsServiceConfig.model_validate(block)
         except PydanticValidationError as exc:
-            logger.error("Invalid [sessions_service] configuration: %s", exc)
-            raise ConfigError(f"Invalid sessions_service configuration: {exc}") from None
+            # Report field/type/message only — never the offending input value.
+            # Pydantic's default rendering embeds ``input_value=...``, which would
+            # leak a secret if ``api_key`` is mistyped (e.g. wrapped in a list) and
+            # still carries the real credential.
+            safe_errors = exc.errors(include_input=False)
+            logger.error("Invalid [sessions_service] configuration: %s", safe_errors)
+            raise ConfigError(f"Invalid sessions_service configuration: {safe_errors}") from None
 
     def validate(self) -> bool:
         """Validate the configuration."""

--- a/tests/unit/agents/config/test_config_specialized_configs.py
+++ b/tests/unit/agents/config/test_config_specialized_configs.py
@@ -320,3 +320,22 @@ class TestGetSessionsConfig:
             lambda key, default=None: None if key == "sessions_service" else default,
         )
         assert base_config.get_sessions_config() is None
+
+    def test_validation_error_does_not_leak_offending_value(self, base_config: Config, caplog, monkeypatch) -> None:
+        # A mistyped api_key (wrapped in a list) still carries the real secret;
+        # neither the raised ConfigError nor the log line may echo the value.
+        secret = "sk-REAL-SECRET-abc123"
+        monkeypatch.setattr(
+            base_config,
+            "get",
+            lambda key, default=None: (
+                {"base_url": "http://s.local", "agent_id": "a1", "api_key": [secret]} if key == "sessions_service" else default
+            ),
+        )
+        with caplog.at_level("ERROR"):
+            with pytest.raises(ConfigError) as excinfo:
+                base_config.get_sessions_config()
+        # Field name is still reported (useful), but never the value.
+        assert "api_key" in str(excinfo.value)
+        assert secret not in str(excinfo.value)
+        assert secret not in caplog.text


### PR DESCRIPTION
Addresses @Mathes76's 🟢 suggestion on the 0.8.0 release PR #90. **Targets 0.8.0** — needs to land on `develop` before the `v0.8.0` tag.

## Problem (confirmed empirically, pydantic 2.13.5)
`get_sessions_config()` interpolated `str(PydanticValidationError)` into both the log line and the raised `ConfigError`. Pydantic embeds `input_value=...` in that text, so a **mistyped `api_key` that still carries the real secret leaks the credential**:

```
api_key
  Input should be a valid string [type=string_type, input_value=['sk-REAL-SECRET-abc123'], input_type=list]
```

Trigger is narrow (the value must fail type validation — e.g. `api_key = ["sk-..."]` in TOML, an env/Dynaconf override collapsing to a list, or a numeric token), so it's low severity — but a real secret *can* reach the logs, which violates our "never log secrets" rule.

## Fix
Build the message from `exc.errors(include_input=False)` — reports field/type/message only, never the value:

```python
except PydanticValidationError as exc:
    safe_errors = exc.errors(include_input=False)
    logger.error("Invalid [sessions_service] configuration: %s", safe_errors)
    raise ConfigError(f"Invalid sessions_service configuration: {safe_errors}") from None
```

Output is now `[{'type': 'string_type', 'loc': ('api_key',), 'msg': 'Input should be a valid string', ...}]` — the field name is still reported (useful for debugging), the value never is. Also cleaner/structured vs. the old multi-line blob.

## Tests
Adds `test_validation_error_does_not_leak_offending_value`: mistypes `api_key` as a list holding a secret, asserts the raised `ConfigError` mentions `api_key` but **not** the secret, and that the secret never appears in the captured log. (`TestGetSessionsConfig` → 8 cases.)

## Verification
Local CI gate green: `ruff check`, `ruff format --check` (228 files), `mypy`, `TestGetSessionsConfig` (8 passed).

## Release note
Folded into the existing `0.8.0` CHANGELOG entry (same accessor, same version); dated `2026-09-07`.

**Merge gated on human review per org policy.** After this merges to `develop`, release PR #90 picks it up automatically — then tag `v0.8.0`.