### PR TITLE
Make docs_url/redoc_url/openapi_url configurable in AppBuilder.build()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+- **`AppBuilder.build()` now sources `docs_url`/`redoc_url`/`openapi_url` from config** (#191, defaults unchanged: `/docs`, `/redoc`, `/openapi.json`). Previously these were hardcoded at `FastAPI()` construction, so a consumer could not disable the built-in `/docs` route without mutating `app.router.routes` after the fact — fragile because it depends on FastAPI's internal route-registration shape (bechtleav360/avs.ai.idac.service-sessions#191). Set `docs_url = "@none"` (Dynaconf's `None` cast) in `settings.toml` to opt out before the route is ever registered. Set at the root of `settings.toml`, not under an `agent_scope` block (`Config._scoped_get()` falls back to the root value when a scoped lookup is `None`). Note FastAPI only registers `docs_url`/`redoc_url` when `openapi_url` is also set, so disabling `openapi_url` disables all three.
+
 ## [0.8.0] - 2026-09-07
 
 ### Added

--- a/src/blueprint/agents/app_builder.py
+++ b/src/blueprint/agents/app_builder.py
@@ -218,9 +218,17 @@ class AppBuilder:
             description=self._config.get("app_description", ""),
             version=self._config.get("app_version", "0.0.0"),
             lifespan=self._create_lifespan_manager(),
-            docs_url="/docs",
-            redoc_url="/redoc",
-            openapi_url="/openapi.json",
+            # Configurable so a consumer can disable a route (docs_url = "@none" in
+            # settings.toml) before FastAPI.__init__ ever registers it (#191) rather
+            # than mutating app.router.routes after construction. Set at the root of
+            # settings.toml, not under an agent_scope block — Config._scoped_get()
+            # treats an explicit None from a scoped key as "not set" and falls back
+            # to the root value, so a scoped override here would be silently ignored.
+            # Note FastAPI itself only registers docs_url/redoc_url when openapi_url
+            # is also set — disabling openapi_url disables all three.
+            docs_url=self._config.get("docs_url", "/docs"),
+            redoc_url=self._config.get("redoc_url", "/redoc"),
+            openapi_url=self._config.get("openapi_url", "/openapi.json"),
         )
 
         self._build_rest_endpoints(app, registry)

--- a/tests/unit/agents/app_builder/test_app_builder.py
+++ b/tests/unit/agents/app_builder/test_app_builder.py
@@ -466,3 +466,69 @@ class TestBuildAppMetadata:
         _, kwargs = all_build_mocks.fastapi.call_args
         assert kwargs["version"] == "0.0.0"
         assert kwargs["description"] == ""
+
+
+# ---------------------------------------------------------------------------
+# build() — docs_url/redoc_url/openapi_url sourced from config (#191)
+#
+# Lets a consumer disable a route (e.g. docs_url = "@none" in settings.toml)
+# before FastAPI.__init__ ever registers it, instead of a downstream consumer
+# mutating app.router.routes after construction (bechtleav360/avs.ai.idac.
+# service-sessions#191).
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDocsUrls:
+    def test_defaults_preserve_current_docs_paths(
+        self,
+        builder_for_build: AppBuilder,
+        mock_registry: MagicMock,
+        all_build_mocks: types.SimpleNamespace,
+        build_config: MagicMock,
+    ) -> None:
+        wire_empty_registry(mock_registry)
+        # Honour the default arg, like a real unset Config.get() would.
+        build_config.get.side_effect = lambda key, default=None: default
+
+        builder_for_build.build()
+
+        _, kwargs = all_build_mocks.fastapi.call_args
+        assert kwargs["docs_url"] == "/docs"
+        assert kwargs["redoc_url"] == "/redoc"
+        assert kwargs["openapi_url"] == "/openapi.json"
+
+    def test_reads_docs_urls_from_config(
+        self,
+        builder_for_build: AppBuilder,
+        mock_registry: MagicMock,
+        all_build_mocks: types.SimpleNamespace,
+        build_config: MagicMock,
+    ) -> None:
+        wire_empty_registry(mock_registry)
+        values = {"docs_url": "/api-docs", "redoc_url": "/api-redoc", "openapi_url": "/api-schema.json"}
+        build_config.get.side_effect = lambda key, default=None: values.get(key, default)
+
+        builder_for_build.build()
+
+        _, kwargs = all_build_mocks.fastapi.call_args
+        assert kwargs["docs_url"] == "/api-docs"
+        assert kwargs["redoc_url"] == "/api-redoc"
+        assert kwargs["openapi_url"] == "/api-schema.json"
+
+    def test_each_url_can_be_individually_disabled(
+        self,
+        builder_for_build: AppBuilder,
+        mock_registry: MagicMock,
+        all_build_mocks: types.SimpleNamespace,
+        build_config: MagicMock,
+    ) -> None:
+        wire_empty_registry(mock_registry)
+        values = {"docs_url": None, "redoc_url": None, "openapi_url": None}
+        build_config.get.side_effect = lambda key, default=None: values.get(key, default)
+
+        builder_for_build.build()
+
+        _, kwargs = all_build_mocks.fastapi.call_args
+        assert kwargs["docs_url"] is None
+        assert kwargs["redoc_url"] is None
+        assert kwargs["openapi_url"] is None


### PR DESCRIPTION
## Summary
- `AppBuilder.build()` now reads `docs_url`/`redoc_url`/`openapi_url` from `Config.get()` instead of hardcoding them at `FastAPI()` construction, with defaults unchanged (`/docs`, `/redoc`, `/openapi.json`).
- Lets a consumer disable a route (e.g. `docs_url = "@none"` in `settings.toml`) before `FastAPI.__init__` ever registers it, instead of mutating `app.router.routes` after construction — root cause investigated and confirmed in bechtleav360/avs.ai.idac.service-sessions#191, where `api_docs.py`'s post-hoc route filter exists specifically because this repo hardcoded `docs_url="/docs"` at construction time, before that repo's code ever sees the app.
- Documented two interaction caveats discovered during review: the override must be set at the root of `settings.toml`, not under an `agent_scope` block (`Config._scoped_get()` falls back to the root value when a scoped lookup is `None`); and FastAPI itself only registers `docs_url`/`redoc_url` when `openapi_url` is also set, so disabling `openapi_url` disables all three.

Refs bechtleav360/avs.ai.idac.service-sessions#191 — this PR unblocks that issue but doesn't close it: service-sessions is pinned to an older `avs-blueprint-agents` version and its `api_docs.py` still needs a follow-up change (and a version bump) to actually consume this and drop its route-mutation filter.

## Test plan
- [x] `uv run pytest tests/unit/agents/app_builder/` — 36 passed (2 new + 1 extended test covering config-driven docs_url/redoc_url/openapi_url, including all three disabled via `None`)
- [x] `uv run pytest tests/unit/` — full unit suite passes
- [x] `uv run ruff check src/ tests/unit/agents/app_builder/`, `black --check`, `mypy src/blueprint/agents/app_builder.py` — all clean
- [x] Confirmed pre-existing `tests/integration/examples/` failures are unrelated (same 29 failures on `develop` before this change)